### PR TITLE
Feature/host

### DIFF
--- a/Hamelin.sln
+++ b/Hamelin.sln
@@ -10,6 +10,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{C0A7AF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hamelin.Tests.Unit", "tests\Hamelin.Tests.Unit\Hamelin.Tests.Unit.csproj", "{66355312-B5AB-4242-8F41-A917CBFD2F7D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{158A0FA9-723E-4F45-863A-29CA977675A0}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\pr.yml = .github\workflows\pr.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Hamelin/Class1.cs
+++ b/src/Hamelin/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace Hamelin;
-
-public class Class1
-{
-}

--- a/src/Hamelin/Hamelin.csproj
+++ b/src/Hamelin/Hamelin.csproj
@@ -15,7 +15,8 @@
     <Version>0.0.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hamelin/Hamelin.csproj
+++ b/src/Hamelin/Hamelin.csproj
@@ -24,4 +24,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/src/Hamelin/PipelineApplication.cs
+++ b/src/Hamelin/PipelineApplication.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace Hamelin;
+
+public class PipelineApplication : IHost
+{
+    private readonly IHost _host;
+
+    internal PipelineApplication(IHost host)
+    {
+        _host = host;
+    }
+
+    public IServiceProvider Services => _host.Services;
+
+    public Task StartAsync(CancellationToken cancellationToken) => _host.StartAsync(cancellationToken);
+    public Task StopAsync(CancellationToken cancellationToken) => _host.StopAsync(cancellationToken);
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        _host.Dispose();
+    }
+
+    public static PipelineApplicationBuilder CreateBuilder() => new(new PipelineApplicationOptions());
+    public static PipelineApplicationBuilder CreateBuilder(string[] args) => new(new PipelineApplicationOptions() { Args = args });
+}

--- a/src/Hamelin/PipelineApplication.cs
+++ b/src/Hamelin/PipelineApplication.cs
@@ -2,26 +2,58 @@
 
 namespace Hamelin;
 
+/// <summary>
+/// Represents a CI/CD pipeline application that can be run.
+/// </summary>
 public class PipelineApplication : IHost
 {
     private readonly IHost _host;
 
+    /// <summary>
+    /// Creates a new instance of the <see cref="PipelineApplication"/> class with the specified host.
+    /// </summary>
+    /// <param name="host">The host that will run the pipeline.</param>
     internal PipelineApplication(IHost host)
     {
         _host = host;
     }
 
+    /// <inheritdoc />
     public IServiceProvider Services => _host.Services;
 
+    /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken) => _host.StartAsync(cancellationToken);
+
+    /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => _host.StopAsync(cancellationToken);
 
+    /// <inheritdoc />
     public void Dispose()
     {
         GC.SuppressFinalize(this);
         _host.Dispose();
     }
 
+    /// <summary>
+    /// Creates a new <see cref="PipelineApplicationBuilder"/> with configured defaults
+    /// that can be used to configure a CI/CD pipeline.
+    /// </summary>
+    /// <returns>The created builder.</returns>
     public static PipelineApplicationBuilder CreateBuilder() => new(new PipelineApplicationOptions());
+
+    /// <summary>
+    /// Creates a new <see cref="PipelineApplicationBuilder"/> with configured defaults
+    /// that can be used to configure a CI/CD pipeline.
+    /// </summary>
+    /// <param name="args">The command-line arguments passed to the application.</param>
+    /// <returns>The created builder.</returns>
     public static PipelineApplicationBuilder CreateBuilder(string[] args) => new(new PipelineApplicationOptions() { Args = args });
+
+    /// <summary>
+    /// Creates a new <see cref="PipelineApplicationBuilder"/> with configured defaults
+    /// that can be used to configure a CI/CD pipeline.
+    /// </summary>
+    /// <param name="options">The options to pass the pipeline builder.</param>
+    /// <returns>The created builder.</returns>
+    public static PipelineApplicationBuilder CreateBuilder(PipelineApplicationOptions options) => new(options);
 }

--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -6,41 +6,63 @@ using Microsoft.Extensions.Logging;
 
 namespace Hamelin;
 
+/// <summary>
+/// Provides functionality to configure and build a CI/CD pipeline application.
+/// </summary>
 public class PipelineApplicationBuilder : IHostApplicationBuilder
 {
     private readonly HostApplicationBuilder _innerBuilder;
 
+    /// <summary>
+    /// Creates a new instance of the <see cref="PipelineApplicationBuilder"/> with the given options.
+    /// </summary>
+    /// <param name="options">The options to configure the pipeline application.</param>
     internal PipelineApplicationBuilder(PipelineApplicationOptions options)
     {
-        var configuration = new ConfigurationManager();
         _innerBuilder = new HostApplicationBuilder(new HostApplicationBuilderSettings
         {
             Args = options.Args,
             ApplicationName = options.ApplicationName,
             EnvironmentName = options.EnvironmentName,
             ContentRootPath = options.ContentRootPath,
-            Configuration = configuration,
+            Configuration = new ConfigurationManager(),
         });
 
-        ApplyDefaultConfiguration(_innerBuilder.Environment, configuration, options.Args);
+        ApplyDefaultConfiguration(_innerBuilder.Environment, _innerBuilder.Configuration, options.Args);
         ApplyDefaultLogging(_innerBuilder.Logging);
         ApplyDefaultMetrics(_innerBuilder.Metrics);
         ApplyDefaultServices(_innerBuilder.Services);
     }
 
+    /// <inheritdoc />
     public IDictionary<object, object> Properties => ((IHostApplicationBuilder)_innerBuilder).Properties;
+
+    /// <inheritdoc />
     public IConfigurationManager Configuration => _innerBuilder.Configuration;
+
+    /// <inheritdoc />
     public IHostEnvironment Environment => _innerBuilder.Environment;
+
+    /// <inheritdoc />
     public ILoggingBuilder Logging => _innerBuilder.Logging;
+
+    /// <inheritdoc />
     public IMetricsBuilder Metrics => _innerBuilder.Metrics;
+
+    /// <inheritdoc />
     public IServiceCollection Services => _innerBuilder.Services;
 
+    /// <summary>
+    /// Builds the <see cref="PipelineApplication" />.
+    /// </summary>
+    /// <returns>The configured pipeline application.</returns>
     public PipelineApplication Build()
     {
         var host = _innerBuilder.Build();
         return new PipelineApplication(host);
     }
 
+    /// <inheritdoc />
     public void ConfigureContainer<TContainerBuilder>(
         IServiceProviderFactory<TContainerBuilder> factory,
         Action<TContainerBuilder>? configure = null
@@ -70,6 +92,8 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
     private static void ApplyDefaultServices(IServiceCollection services)
     {
         // TODO: Configure services.
-        // At least one `IHostedService` should be registered to run the application.
+
+        // This is the service responsible for running the pipeline.
+        services.AddHostedService<PipelineHost>();
     }
 }

--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Hamelin;
+
+public class PipelineApplicationBuilder : IHostApplicationBuilder
+{
+    private readonly HostApplicationBuilder _innerBuilder;
+
+    internal PipelineApplicationBuilder(PipelineApplicationOptions options)
+    {
+        var configuration = new ConfigurationManager();
+        _innerBuilder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            Args = options.Args,
+            ApplicationName = options.ApplicationName,
+            EnvironmentName = options.EnvironmentName,
+            ContentRootPath = options.ContentRootPath,
+            Configuration = configuration,
+        });
+
+        ApplyDefaultConfiguration(_innerBuilder.Environment, configuration, options.Args);
+        ApplyDefaultLogging(_innerBuilder.Logging);
+        ApplyDefaultMetrics(_innerBuilder.Metrics);
+        ApplyDefaultServices(_innerBuilder.Services);
+    }
+
+    public IDictionary<object, object> Properties => ((IHostApplicationBuilder)_innerBuilder).Properties;
+    public IConfigurationManager Configuration => _innerBuilder.Configuration;
+    public IHostEnvironment Environment => _innerBuilder.Environment;
+    public ILoggingBuilder Logging => _innerBuilder.Logging;
+    public IMetricsBuilder Metrics => _innerBuilder.Metrics;
+    public IServiceCollection Services => _innerBuilder.Services;
+
+    public PipelineApplication Build()
+    {
+        var host = _innerBuilder.Build();
+        return new PipelineApplication(host);
+    }
+
+    public void ConfigureContainer<TContainerBuilder>(
+        IServiceProviderFactory<TContainerBuilder> factory,
+        Action<TContainerBuilder>? configure = null
+    ) where TContainerBuilder : notnull => _innerBuilder.ConfigureContainer(factory, configure);
+
+    private static void ApplyDefaultConfiguration(IHostEnvironment environment, ConfigurationManager configuration, string[]? args)
+    {
+        // Logic adapted from https://github.com/dotnet/runtime/blob/6149ca07d2202c2d0d518e10568c0d0dd3473576/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L229-L256
+        bool reloadOnChange = configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
+        configuration
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
+            .AddJsonFile($"appsettings.{environment.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange)
+            .AddEnvironmentVariables()
+            .AddCommandLine(args ?? []);
+    }
+
+    private static void ApplyDefaultLogging(ILoggingBuilder logging)
+    {
+        // TODO: Configure logging.
+    }
+
+    private static void ApplyDefaultMetrics(IMetricsBuilder metrics)
+    {
+        // TODO: Configure metrics.
+    }
+
+    private static void ApplyDefaultServices(IServiceCollection services)
+    {
+        // TODO: Configure services.
+        // At least one `IHostedService` should be registered to run the application.
+    }
+}

--- a/src/Hamelin/PipelineApplicationOptions.cs
+++ b/src/Hamelin/PipelineApplicationOptions.cs
@@ -1,0 +1,9 @@
+namespace Hamelin;
+
+public class PipelineApplicationOptions
+{
+    public string[]? Args { get; init; }
+    public string? EnvironmentName { get; init; }
+    public string? ApplicationName { get; init; }
+    public string? ContentRootPath { get; init; }
+}

--- a/src/Hamelin/PipelineApplicationOptions.cs
+++ b/src/Hamelin/PipelineApplicationOptions.cs
@@ -1,9 +1,27 @@
 namespace Hamelin;
 
+/// <summary>
+/// Settings for constructing a <see cref="PipelineApplicationBuilder"/>.
+/// </summary>
 public class PipelineApplicationOptions
 {
+    /// <summary>
+    /// Gets or sets the command-line arguments to add to the <see cref="PipelineApplicationBuilder.Configuration"/>.
+    /// </summary>
     public string[]? Args { get; init; }
+
+    /// <summary>
+    /// Gets or sets the environment name.
+    /// </summary>
     public string? EnvironmentName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the application name.
+    /// </summary>
     public string? ApplicationName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the content root path.
+    /// </summary>
     public string? ContentRootPath { get; init; }
 }

--- a/src/Hamelin/PipelineHost.cs
+++ b/src/Hamelin/PipelineHost.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Hamelin;
+
+/// <summary>
+/// The hosted service that runs the pipeline.
+/// </summary>
+/// <param name="lifetime">The application lifetime.</param>
+internal class PipelineHost(IHostApplicationLifetime lifetime) : IHostedService
+{
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // TODO: Implement the logic to run the pipeline.
+        Console.WriteLine("This is where the pipeline should get run.");
+
+        // Exit the application gracefully now that the pipeline has run.
+        lifetime.StopApplication();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/tests/Hamelin.Tests.Unit/Hamelin.Tests.Unit.csproj
+++ b/tests/Hamelin.Tests.Unit/Hamelin.Tests.Unit.csproj
@@ -23,4 +23,8 @@
     <Using Include="Shouldly"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hamelin\Hamelin.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Hamelin.Tests.Unit/PipelineApplicationTests.cs
+++ b/tests/Hamelin.Tests.Unit/PipelineApplicationTests.cs
@@ -1,16 +1,18 @@
+using Microsoft.Extensions.Hosting;
+
 namespace Hamelin.Tests.Unit;
 
 public class PipelineApplicationTests
 {
     [Fact]
-    public async Task StartAsync_DoesNotThrow()
+    public async Task RunAsync_DoesNotThrowOrHang()
     {
         // Arrange
         var builder = PipelineApplication.CreateBuilder();
         var pipeline = builder.Build();
 
         // Act
-        var act = () => pipeline.StartAsync(CancellationToken.None);
+        var act = () => pipeline.RunAsync();
 
         // Assert
         await act.ShouldNotThrowAsync();

--- a/tests/Hamelin.Tests.Unit/PipelineApplicationTests.cs
+++ b/tests/Hamelin.Tests.Unit/PipelineApplicationTests.cs
@@ -3,14 +3,13 @@ namespace Hamelin.Tests.Unit;
 public class PipelineApplicationTests
 {
     [Fact]
-    public async Task CreateBuilder_ShouldReturnPipelineApplicationBuilder()
+    public async Task StartAsync_DoesNotThrow()
     {
         // Arrange
-        string[] args = ["arg1", "arg2"];
+        var builder = PipelineApplication.CreateBuilder();
+        var pipeline = builder.Build();
 
         // Act
-        var builder = PipelineApplication.CreateBuilder(args);
-        var pipeline = builder.Build();
         var act = () => pipeline.StartAsync(CancellationToken.None);
 
         // Assert

--- a/tests/Hamelin.Tests.Unit/PipelineApplicationTests.cs
+++ b/tests/Hamelin.Tests.Unit/PipelineApplicationTests.cs
@@ -1,0 +1,19 @@
+namespace Hamelin.Tests.Unit;
+
+public class PipelineApplicationTests
+{
+    [Fact]
+    public async Task CreateBuilder_ShouldReturnPipelineApplicationBuilder()
+    {
+        // Arrange
+        string[] args = ["arg1", "arg2"];
+
+        // Act
+        var builder = PipelineApplication.CreateBuilder(args);
+        var pipeline = builder.Build();
+        var act = () => pipeline.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldNotThrowAsync();
+    }
+}

--- a/tests/Hamelin.Tests.Unit/UnitTest1.cs
+++ b/tests/Hamelin.Tests.Unit/UnitTest1.cs
@@ -1,9 +1,0 @@
-﻿namespace Hamelin.Tests.Unit;
-
-public class UnitTest1
-{
-    [Fact]
-    public void Test1()
-    {
-    }
-}


### PR DESCRIPTION
This PR adds a very barebones `PipelineApplicationBuilder` that follows the same pattern as the existing builders like the `WebApplicationBuilder`. The intended usage looks like this:

```cs
var builder = PipelineApplication.CreateBuilder();
// Service and configuration setup goes here.

var pipeline = builder.Build();
// I think pipeline logic should go here, rather than in the builder the same way you call `MapGet` for minimal APIs, maybe we should have `AddStep()` or something?

await pipeline.RunAsync();
```

The `PipelineApplicationBuilder` essentially wraps the `HostApplicationBuilder` with the default configuration. We'll need to look at configuration, logging, metrics, etc. but for now it includes the standard configuration (appsettings, appsettings.env, and environment variables).

Internally, "running" an `IHost` consists of resolving all `IHostedService` instances from the service provider and calling `StartAsync`, then the application runs indefinitely until something requests it to stop. The `PipelineHost` hosted service therefore exists to run the pipeline logic then request the application to stop.