### PR TITLE
Switch to BackgroundService and provide option to not halt application

### DIFF
--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -1,6 +1,7 @@
 using Hamelin.Steps;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Hamelin.Internal;
 
@@ -9,13 +10,31 @@ namespace Hamelin.Internal;
 /// </summary>
 /// <param name="lifetime">The application lifetime.</param>
 /// <param name="scopeFactory">The factory that will be used to scope each execution of the pipeline.</param>
+/// <param name="options">Options to configure the pipeline execution</param>
 internal class PipelineHost(
     IHostApplicationLifetime lifetime,
-    IServiceScopeFactory scopeFactory
-) : IHostedService
+    IServiceScopeFactory scopeFactory,
+    IOptions<PipelineHostOptions> options
+) : BackgroundService
 {
     /// <inheritdoc />
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RunPipeline(cancellationToken);
+        }
+        finally
+        {
+            if (options.Value.StopApplicationOnCompletion)
+            {
+                // Exit the application gracefully now that the pipeline has run.
+                lifetime.StopApplication();
+            }
+        }
+    }
+
+    private async Task RunPipeline(CancellationToken cancellationToken)
     {
         // Resolve the steps from a scoped service provider.
         await using var scope = scopeFactory.CreateAsyncScope();
@@ -25,13 +44,12 @@ internal class PipelineHost(
         // Run each step in the pipeline.
         foreach (var step in steps)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             await step.Run(cancellationToken);
         }
-
-        // Exit the application gracefully now that the pipeline has run.
-        lifetime.StopApplication();
     }
-
-    /// <inheritdoc />
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -14,7 +14,7 @@ namespace Hamelin.Internal;
 internal class PipelineHost(
     IHostApplicationLifetime lifetime,
     IServiceScopeFactory scopeFactory,
-    IOptions<PipelineHostOptions> options
+    IOptions<PipelineExecutionOptions> options
 ) : BackgroundService
 {
     /// <inheritdoc />

--- a/src/Hamelin/Internal/PipelineHostOptions.cs
+++ b/src/Hamelin/Internal/PipelineHostOptions.cs
@@ -1,0 +1,13 @@
+namespace Hamelin.Internal;
+
+/// <summary>
+/// Settings for the pipeline host
+/// </summary>
+public class PipelineHostOptions
+{
+    /// <summary>
+    /// If `true` then application termination will be requested the pipeline run is completed
+    /// </summary>
+    // ReSharper disable once PropertyCanBeMadeInitOnly.Global
+    public bool StopApplicationOnCompletion { get; init; } =  true;
+}

--- a/src/Hamelin/PipelineExecutionOptions.cs
+++ b/src/Hamelin/PipelineExecutionOptions.cs
@@ -1,13 +1,12 @@
-namespace Hamelin.Internal;
+namespace Hamelin;
 
 /// <summary>
-/// Settings for the pipeline host
+/// Settings to control the execution of the pipeline
 /// </summary>
-public class PipelineHostOptions
+public class PipelineExecutionOptions
 {
     /// <summary>
     /// If `true` then application termination will be requested the pipeline run is completed
     /// </summary>
-    // ReSharper disable once PropertyCanBeMadeInitOnly.Global
     public bool StopApplicationOnCompletion { get; init; } =  true;
 }

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -22,12 +22,12 @@ public class PipelineHostTests
 
         var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
 
-        PipelineHostOptions pipelineHostOptions = new()
+        PipelineExecutionOptions pipelineExecutionOptions = new()
         {
             StopApplicationOnCompletion = true
         };
 
-        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineHostOptions));
+        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -49,12 +49,12 @@ public class PipelineHostTests
 
         var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
 
-        PipelineHostOptions pipelineHostOptions = new()
+        PipelineExecutionOptions pipelineExecutionOptions = new()
         {
             StopApplicationOnCompletion = false
         };
 
-        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineHostOptions));
+        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -82,9 +82,9 @@ public class PipelineHostTests
 
         var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
 
-        PipelineHostOptions pipelineHostOptions = new();
+        PipelineExecutionOptions pipelineExecutionOptions = new();
 
-        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineHostOptions));
+        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -3,13 +3,14 @@ using Hamelin.Steps;
 using Hamelin.Tests.Unit.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Hamelin.Tests.Unit.Internal;
 
 public class PipelineHostTests
 {
     [Fact]
-    public async Task StartAsync_StopsApplicationWhenFinished()
+    public async Task StartAsync_WithStopApplicationOnCompletion_StopsApplicationWhenFinished()
     {
         // Arrange
         var lifetime = Substitute.For<IHostApplicationLifetime>();
@@ -21,13 +22,45 @@ public class PipelineHostTests
 
         var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
 
-        var host = new PipelineHost(lifetime, scopeFactory);
+        PipelineHostOptions pipelineHostOptions = new()
+        {
+            StopApplicationOnCompletion = true
+        };
+
+        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineHostOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);
 
         // Assert
         lifetime.Received().StopApplication();
+    }
+
+    [Fact]
+    public async Task StartAsync_WithoutStopApplicationOnCompletion_DoesNotStopApplicationWhenFinished()
+    {
+        // Arrange
+        var lifetime = Substitute.For<IHostApplicationLifetime>();
+
+        var provider = Substitute.For<IPipelineStepProvider>();
+        var services = new ServiceCollection()
+            .AddSingleton(provider)
+            .BuildServiceProvider();
+
+        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
+
+        PipelineHostOptions pipelineHostOptions = new()
+        {
+            StopApplicationOnCompletion = false
+        };
+
+        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineHostOptions));
+
+        // Act
+        await host.StartAsync(CancellationToken.None);
+
+        // Assert
+        lifetime.DidNotReceive().StopApplication();
     }
 
     [Fact]
@@ -49,7 +82,9 @@ public class PipelineHostTests
 
         var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
 
-        var host = new PipelineHost(lifetime, scopeFactory);
+        PipelineHostOptions pipelineHostOptions = new();
+
+        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineHostOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);


### PR DESCRIPTION
### Switches `PipelineHost` from `IHostedService` to `BackgroundService`.
This moves the actual execution of the steps out of `StartAsync`. `StartAsync` is supposed to exit fairly quickly, and a pipeline run may take several minutes. Services are started sequentially, and further services can't start until `StartAsync` completes.

### Adds an option to determine whether pipeline completion will trigger the application to stop.
In advanced use cases Hamelin might be running alongside some other services. This allows Hamelin users more control over their application lifetime.