### PR TITLE
File System Abstraction

### DIFF
--- a/src/Hamelin/FileSystem/IDirectory.cs
+++ b/src/Hamelin/FileSystem/IDirectory.cs
@@ -1,0 +1,66 @@
+namespace Hamelin.FileSystem;
+
+/// <summary>
+/// Represents a directory in the file system.
+/// </summary>
+public interface IDirectory
+{
+    /// <summary>
+    /// Gets the name of the directory.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the full path to the directory.
+    /// </summary>
+    string Path { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this directory exists in the file system.
+    /// </summary>
+    bool Exists { get; }
+
+    // Actions
+
+    /// <summary>
+    /// Creates this directory in the file system.
+    /// </summary>
+    void Create();
+
+    /// <summary>
+    /// Deletes this directory and its contents.
+    /// </summary>
+    void Delete();
+
+    // Navigation
+
+    /// <summary>
+    /// Gets the file with the specified name within this directory.
+    /// </summary>
+    /// <param name="name">The name of the file to get.</param>
+    /// <returns>The file object, regardless of whether the underlying file actually exists.</returns>
+    IFile GetFile(string name);
+
+    /// <summary>
+    /// Gets the directory with the specified name within this directory.
+    /// </summary>
+    /// <param name="name">The name of the directory to get.</param>
+    /// <returns>The directory object, regardless of whether the underlying directory actually exists.</returns>
+    IDirectory GetDirectory(string name);
+
+    /// <summary>
+    /// Gets the files contained in this directory.
+    /// </summary>
+    /// <param name="searchPattern">The search pattern to match files against. Supports globbing.</param>
+    /// <param name="recursive">If true, searches subdirectories recursively.</param>
+    /// <returns>The files in this directory.</returns>
+    IEnumerable<IFile> GetFiles(string searchPattern = "*.*", bool recursive = false);
+
+    /// <summary>
+    /// Gets the subdirectories contained in this directory.
+    /// </summary>
+    /// <param name="searchPattern">The search pattern to match directories against. Supports globbing.</param>
+    /// <param name="recursive">If true, searches subdirectories recursively.</param>
+    /// <returns>The discovered directories.</returns>
+    IEnumerable<IDirectory> GetDirectories(string searchPattern = "*", bool recursive = false);
+}

--- a/src/Hamelin/FileSystem/IFile.cs
+++ b/src/Hamelin/FileSystem/IFile.cs
@@ -1,0 +1,39 @@
+namespace Hamelin.FileSystem;
+
+/// <summary>
+/// Represents a file in the file system.
+/// </summary>
+public interface IFile
+{
+    /// <summary>
+    /// Gets the name of the file, including the extension.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the full path to the file.
+    /// </summary>
+    string Path { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this directory exists in the file system.
+    /// </summary>
+    bool Exists { get; }
+
+    /// <summary>
+    /// Deletes this file from the file system.
+    /// </summary>
+    void Delete();
+
+    /// <summary>
+    /// Opens the file for reading.
+    /// </summary>
+    /// <returns>A stream that can be read from.</returns>
+    Stream OpenRead();
+
+    /// <summary>
+    /// Opens the file for writing. If the file does not exist, it will be created.
+    /// </summary>
+    /// <returns>A stream that can be written to.</returns>
+    Stream OpenWrite();
+}

--- a/src/Hamelin/FileSystem/IFileSystem.cs
+++ b/src/Hamelin/FileSystem/IFileSystem.cs
@@ -1,0 +1,12 @@
+namespace Hamelin.FileSystem;
+
+/// <summary>
+/// Provides an abstraction for file system operations.
+/// </summary>
+public interface IFileSystem
+{
+    /// <summary>
+    /// Gets the current working directory.
+    /// </summary>
+    IDirectory CurrentDirectory { get; }
+}

--- a/src/Hamelin/FileSystem/Physical/PhysicalDirectory.cs
+++ b/src/Hamelin/FileSystem/Physical/PhysicalDirectory.cs
@@ -1,0 +1,30 @@
+namespace Hamelin.FileSystem.Physical;
+
+internal class PhysicalDirectory(string path) : IDirectory
+{
+    public string Name { get; } = System.IO.Path.GetFileName(path);
+    public string Path { get; } = path;
+    public bool Exists => Directory.Exists(Path);
+
+    public void Create() => Directory.CreateDirectory(Path);
+    public void Delete() => Directory.Delete(Path, true);
+
+    public IFile GetFile(string name) => new PhysicalFile(System.IO.Path.Combine(Path, name));
+    public IDirectory GetDirectory(string name) => new  PhysicalDirectory(System.IO.Path.Combine(Path, name));
+
+    public IEnumerable<IFile> GetFiles(string searchPattern = "*.*", bool recursive = false)
+    {
+        // TODO: Support searching.
+        return Directory
+            .EnumerateFiles(Path)
+            .Select(path => new PhysicalFile(path));
+    }
+
+    public IEnumerable<IDirectory> GetDirectories(string searchPattern = "*", bool recursive = false)
+    {
+        // TODO: Support searching.
+        return Directory
+            .EnumerateFiles(Path)
+            .Select(path => new PhysicalDirectory(path));
+    }
+}

--- a/src/Hamelin/FileSystem/Physical/PhysicalFile.cs
+++ b/src/Hamelin/FileSystem/Physical/PhysicalFile.cs
@@ -1,0 +1,11 @@
+namespace Hamelin.FileSystem.Physical;
+
+internal class PhysicalFile(string path) : IFile
+{
+    public string Name { get; } = System.IO.Path.GetFileName(path);
+    public string Path { get; } = path;
+    public bool Exists => File.Exists(Path);
+    public void Delete() => File.Delete(Path);
+    public Stream OpenRead() => File.OpenRead(Path);
+    public Stream OpenWrite() => File.OpenWrite(Path);
+}

--- a/src/Hamelin/FileSystem/Physical/PhysicalFileSystem.cs
+++ b/src/Hamelin/FileSystem/Physical/PhysicalFileSystem.cs
@@ -1,0 +1,6 @@
+namespace Hamelin.FileSystem.Physical;
+
+internal class PhysicalFileSystem(string path) : IFileSystem
+{
+    public IDirectory CurrentDirectory { get; } = new PhysicalDirectory(path);
+}

--- a/src/Hamelin/IPipelineContext.cs
+++ b/src/Hamelin/IPipelineContext.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.FileProviders;
+using Hamelin.FileSystem;
 
 namespace Hamelin;
 
@@ -10,7 +10,7 @@ public interface IPipelineContext
     /// <summary>
     /// Gets the file system provider used by the pipeline.
     /// </summary>
-    IFileProvider FileSystem { get; }
+    IFileSystem FileSystem { get; }
 
     /// <summary>
     /// Gets the state of the pipeline, which can be used to store and retrieve data between steps.

--- a/src/Hamelin/Internal/DefaultPipelineContext.cs
+++ b/src/Hamelin/Internal/DefaultPipelineContext.cs
@@ -1,11 +1,11 @@
-using Microsoft.Extensions.FileProviders;
+using Hamelin.FileSystem;
 using Microsoft.Extensions.Hosting;
 
 namespace Hamelin.Internal;
 
-internal class DefaultPipelineContext(IFileProvider fileSystem, IPipelineState state, IHostEnvironment env) : IPipelineContext
+internal class DefaultPipelineContext(IFileSystem fileSystem, IPipelineState state, IHostEnvironment env) : IPipelineContext
 {
-    public IFileProvider FileSystem { get; } = fileSystem;
+    public IFileSystem FileSystem { get; } = fileSystem;
     public IPipelineState State { get; } = state;
     public string CurrentDirectory { get; } = env.ContentRootPath;
 }

--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -1,11 +1,12 @@
 using Hamelin.Extensions;
+using Hamelin.FileSystem;
+using Hamelin.FileSystem.Physical;
 using Hamelin.Internal;
 using Hamelin.Steps;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.Metrics;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -86,7 +87,7 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
 
     private void ApplyServices(IServiceCollection services)
     {
-        services.TryAddScoped<IFileProvider>(_ => new PhysicalFileProvider(_innerBuilder.Environment.ContentRootPath));
+        services.TryAddScoped<IFileSystem>(_ => new PhysicalFileSystem(_innerBuilder.Environment.ContentRootPath));
         services.TryAddScoped<IPipelineState, DefaultPipelineState>();
         services.TryAddScoped<IPipelineContext, DefaultPipelineContext>();
 


### PR DESCRIPTION
The `IFileProvider` interface only provides readonly access, which doesn't fit our use case, so we need a better abstraction.

`TestableIO` was a good shout, but it just provides abstraction over the existing `System.IO.File` and `System.IO.Directory` namespaces, and we need something a bit more curated.