### PR TITLE
Fix Default Content Root

### DIFF
--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -32,12 +32,17 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
             { "Logging:LogLevel:Microsoft.Hosting.Lifetime", nameof(LogLevel.Warning) }
         });
 
+        // When left empty, the content root usually defaults to the current working directory.
+        // Since Hamelin will usually be run from a project/repository directory, it won't be able to
+        // find things like appsettings.json.
+        string contentRoot = options.ContentRootPath ?? AppContext.BaseDirectory;
+
         _innerBuilder = new HostApplicationBuilder(new HostApplicationBuilderSettings
         {
             Args = options.Args,
             ApplicationName = options.ApplicationName,
             EnvironmentName = options.EnvironmentName,
-            ContentRootPath = options.ContentRootPath,
+            ContentRootPath = contentRoot,
             Configuration = configuration,
         });
     }


### PR DESCRIPTION
When left empty, the content root [usually defaults to the current working directory](https://github.com/dotnet/runtime/blob/3c94a470bc7fbdabafdf5d224b48dc5500e1b3b3/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L211). Since Hamelin will usually be run from a project/repository directory, it won't be able to pick up `appsettings.json` from its local directory.

By defaulting to `AppContext.BaseDirectory` instead of the CWD, we can find `appsettings.json` while still letting users override the content root if necessary.