### PR TITLE
Use correct current directory.

### DIFF
--- a/src/Hamelin/Internal/DefaultPipelineContext.cs
+++ b/src/Hamelin/Internal/DefaultPipelineContext.cs
@@ -3,9 +3,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace Hamelin.Internal;
 
-internal class DefaultPipelineContext(IFileSystem fileSystem, IPipelineState state, IHostEnvironment env) : IPipelineContext
+internal class DefaultPipelineContext(IFileSystem fileSystem, IPipelineState state) : IPipelineContext
 {
     public IFileSystem FileSystem { get; } = fileSystem;
     public IPipelineState State { get; } = state;
-    public string CurrentDirectory { get; } = env.ContentRootPath;
+    public string CurrentDirectory => Environment.CurrentDirectory;
 }


### PR DESCRIPTION
Now that we're setting the content root to the app context base directory, we should stop returning that from the `CurrentDirectory` property and instead return the... current directory.