### PR TITLE
Add Format Step

### DIFF
--- a/build/Hamelin.Build/Hamelin.Build.csproj
+++ b/build/Hamelin.Build/Hamelin.Build.csproj
@@ -17,4 +17,8 @@
       </None>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="CliWrap" Version="3.9.0" />
+    </ItemGroup>
+
 </Project>

--- a/build/Hamelin.Build/Program.cs
+++ b/build/Hamelin.Build/Program.cs
@@ -16,6 +16,8 @@ builder.Services.AddOptions<BuildOptions>()
 
 var pipeline = builder.Build();
 
-pipeline.UseStep<CleanStep>();
+pipeline
+    .UseStep<CleanStep>()
+    .UseStep<FormatStep>();
 
 pipeline.Run();

--- a/build/Hamelin.Build/Program.cs
+++ b/build/Hamelin.Build/Program.cs
@@ -1,12 +1,15 @@
 ﻿using Hamelin;
 using Hamelin.Build;
+using Hamelin.Build.Services;
 using Hamelin.Build.Steps;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var builder = PipelineApplication.CreateBuilder(args);
 
-builder.Services.AddStepsFromAssemblyContaining<Program>();
+builder.Services
+    .AddScoped<ICommandRunner, CliWrapCommandRunner>()
+    .AddStepsFromAssemblyContaining<Program>();
 
 builder.Services.AddOptions<BuildOptions>()
     .BindConfiguration("Build")

--- a/build/Hamelin.Build/Services/CliWrapCommandRunner.cs
+++ b/build/Hamelin.Build/Services/CliWrapCommandRunner.cs
@@ -1,0 +1,41 @@
+using CliWrap;
+using CliWrap.EventStream;
+using Microsoft.Extensions.Logging;
+
+namespace Hamelin.Build.Services;
+
+public class CliWrapCommandRunner(ILogger<CliWrapCommandRunner> logger, IPipelineContext context) : ICommandRunner
+{
+    public async Task Run(string command, string[] arguments, CancellationToken cancellationToken)
+    {
+        var cmd = Cli.Wrap(command)
+            .WithArguments(arguments)
+            .WithWorkingDirectory(context.CurrentDirectory)
+            .WithValidation(CommandResultValidation.None);
+
+        logger.LogInformation("Running command: {Command}", command);
+
+        await foreach (var cmdEvent in cmd.ListenAsync(cancellationToken))
+        {
+            switch (cmdEvent)
+            {
+                case StartedCommandEvent started:
+                    logger.LogInformation("Process started; ID: {ProcessId}", started.ProcessId);
+                    break;
+                case StandardOutputCommandEvent stdOut:
+                    logger.LogInformation("{Output}", stdOut.Text);
+                    break;
+                case StandardErrorCommandEvent stdErr:
+                    logger.LogError("{Error}", stdErr.Text);
+                    break;
+                case ExitedCommandEvent exited:
+                    logger.LogInformation("Process exited; Code: {ExitCode}", exited.ExitCode);
+                    if (exited.ExitCode != 0)
+                    {
+                        throw new Exception($"Command {command} returned exit code {exited.ExitCode}");
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/build/Hamelin.Build/Services/CliWrapCommandRunner.cs
+++ b/build/Hamelin.Build/Services/CliWrapCommandRunner.cs
@@ -13,7 +13,7 @@ public class CliWrapCommandRunner(ILogger<CliWrapCommandRunner> logger, IPipelin
             .WithWorkingDirectory(context.CurrentDirectory)
             .WithValidation(CommandResultValidation.None);
 
-        logger.LogInformation("Running command: {Command}", command);
+        logger.LogInformation("Running command: {Command}", cmd);
 
         await foreach (var cmdEvent in cmd.ListenAsync(cancellationToken))
         {

--- a/build/Hamelin.Build/Services/ICommandRunner.cs
+++ b/build/Hamelin.Build/Services/ICommandRunner.cs
@@ -1,0 +1,6 @@
+namespace Hamelin.Build.Services;
+
+public interface ICommandRunner
+{
+    Task Run(string command, string[] arguments, CancellationToken cancellationToken);
+}

--- a/build/Hamelin.Build/Steps/FormatStep.cs
+++ b/build/Hamelin.Build/Steps/FormatStep.cs
@@ -22,11 +22,11 @@ public class FormatStep(ILogger<FormatStep> logger, IPipelineContext context) : 
 
         if (result.ExitCode == 0)
         {
-           logger.LogInformation("{StdOut}", stdOutBuffer);
+           logger.LogInformation("Output: {StdOut}", stdOutBuffer);
         }
         else
         {
-            logger.LogError("{StdErr}", stdErrBuffer);
+            logger.LogError("Error: {StdErr}", stdErrBuffer);
             throw new Exception($"Command {command} returned exit code {result.ExitCode}");
         }
     }

--- a/build/Hamelin.Build/Steps/FormatStep.cs
+++ b/build/Hamelin.Build/Steps/FormatStep.cs
@@ -1,46 +1,15 @@
-using System.Text;
-using CliWrap;
-using CliWrap.EventStream;
-using Microsoft.Extensions.Logging;
+using Hamelin.Build.Services;
 
 namespace Hamelin.Build.Steps;
 
-public class FormatStep(ILogger<FormatStep> logger, IPipelineContext context) : IPipelineStep
+public class FormatStep(ICommandRunner commands) : IPipelineStep
 {
     public async Task Run(CancellationToken cancellationToken = default)
     {
-        var stdOutBuffer = new StringBuilder();
-        var stdErrBuffer = new StringBuilder();
-        var command = Cli.Wrap("dotnet")
-            .WithArguments(["format", "--verify-no-changes"])
-            .WithWorkingDirectory(context.CurrentDirectory)
-            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
-            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer))
-            .WithValidation(CommandResultValidation.None);
-
-        logger.LogInformation("Running command: {Command}", command);
-
-        await foreach (var cmdEvent in command.ListenAsync(cancellationToken))
-        {
-            switch (cmdEvent)
-            {
-                case StartedCommandEvent started:
-                    logger.LogInformation("Process started; ID: {ProcessId}", started.ProcessId);
-                    break;
-                case StandardOutputCommandEvent stdOut:
-                    logger.LogInformation("{Output}", stdOut.Text);
-                    break;
-                case StandardErrorCommandEvent stdErr:
-                    logger.LogError("{Error}", stdErr.Text);
-                    break;
-                case ExitedCommandEvent exited:
-                    logger.LogInformation("Process exited; Code: {ExitCode}", exited.ExitCode);
-                    if (exited.ExitCode != 0)
-                    {
-                        throw new Exception($"Command {command} returned exit code {exited.ExitCode}");
-                    }
-                    break;
-            }
-        }
+        await commands.Run(
+            command: "dotnet",
+            arguments: ["format", "--verify-no-changes"],
+            cancellationToken
+        );
     }
 }

--- a/build/Hamelin.Build/Steps/FormatStep.cs
+++ b/build/Hamelin.Build/Steps/FormatStep.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using CliWrap;
+using CliWrap.EventStream;
 using Microsoft.Extensions.Logging;
 
 namespace Hamelin.Build.Steps;
@@ -18,16 +19,28 @@ public class FormatStep(ILogger<FormatStep> logger, IPipelineContext context) : 
             .WithValidation(CommandResultValidation.None);
 
         logger.LogInformation("Running command: {Command}", command);
-        var result = await command.ExecuteAsync(cancellationToken);
 
-        if (result.ExitCode == 0)
+        await foreach (var cmdEvent in command.ListenAsync(cancellationToken))
         {
-           logger.LogInformation("Output: {StdOut}", stdOutBuffer);
-        }
-        else
-        {
-            logger.LogError("Error: {StdErr}", stdErrBuffer);
-            throw new Exception($"Command {command} returned exit code {result.ExitCode}");
+            switch (cmdEvent)
+            {
+                case StartedCommandEvent started:
+                    logger.LogInformation("Process started; ID: {ProcessId}", started.ProcessId);
+                    break;
+                case StandardOutputCommandEvent stdOut:
+                    logger.LogInformation("{Output}", stdOut.Text);
+                    break;
+                case StandardErrorCommandEvent stdErr:
+                    logger.LogError("{Error}", stdErr.Text);
+                    break;
+                case ExitedCommandEvent exited:
+                    logger.LogInformation("Process exited; Code: {ExitCode}", exited.ExitCode);
+                    if (exited.ExitCode != 0)
+                    {
+                        throw new Exception($"Command {command} returned exit code {exited.ExitCode}");
+                    }
+                    break;
+            }
         }
     }
 }

--- a/build/Hamelin.Build/Steps/FormatStep.cs
+++ b/build/Hamelin.Build/Steps/FormatStep.cs
@@ -1,0 +1,33 @@
+using System.Text;
+using CliWrap;
+using Microsoft.Extensions.Logging;
+
+namespace Hamelin.Build.Steps;
+
+public class FormatStep(ILogger<FormatStep> logger, IPipelineContext context) : IPipelineStep
+{
+    public async Task Run(CancellationToken cancellationToken = default)
+    {
+        var stdOutBuffer = new StringBuilder();
+        var stdErrBuffer = new StringBuilder();
+        var command = Cli.Wrap("dotnet")
+            .WithArguments(["format", "--verify-no-changes"])
+            .WithWorkingDirectory(context.CurrentDirectory)
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
+            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer))
+            .WithValidation(CommandResultValidation.None);
+
+        logger.LogInformation("Running command: {Command}", command);
+        var result = await command.ExecuteAsync(cancellationToken);
+
+        if (result.ExitCode == 0)
+        {
+           logger.LogInformation("{StdOut}", stdOutBuffer);
+        }
+        else
+        {
+            logger.LogError("{StdErr}", stdErrBuffer);
+            throw new Exception($"Command {command} returned exit code {result.ExitCode}");
+        }
+    }
+}


### PR DESCRIPTION
Adds a formatting step to the bootstrap builder. Here's an example output:

```
info: Hamelin.Build.Steps.CleanStep[0]
      Cleaning temp and artifact directories.
info: Hamelin.Build.Steps.FormatStep[0]
      Running command: dotnet format --verify-no-changes
info: Hamelin.Build.Steps.FormatStep[0]
      Process started; ID: 7920
fail: Hamelin.Build.Steps.FormatStep[0]
      /Users/tomwolfe/Development/Hamelin/src/Hamelin/IPipelineContext.cs(8,34): error WHITESPACE: Fix whitespace formatting. Replace 1 characters with '\n'. [/Users/tomwolfe/Development/Hamelin/src/Hamelin/Hamelin.csproj]
info: Hamelin.Build.Steps.FormatStep[0]
      Process exited; Code: 2
```