### PR TITLE
Add Termination Mode

### DIFF
--- a/src/Hamelin/IPipelineContext.cs
+++ b/src/Hamelin/IPipelineContext.cs
@@ -5,7 +5,8 @@ namespace Hamelin;
 /// <summary>
 /// Provides context for the pipeline execution.
 /// </summary>
-public interface IPipelineContext {
+public interface IPipelineContext
+{
     /// <summary>
     /// Gets the file system provider used by the pipeline.
     /// </summary>

--- a/src/Hamelin/IPipelineContext.cs
+++ b/src/Hamelin/IPipelineContext.cs
@@ -5,8 +5,7 @@ namespace Hamelin;
 /// <summary>
 /// Provides context for the pipeline execution.
 /// </summary>
-public interface IPipelineContext
-{
+public interface IPipelineContext {
     /// <summary>
     /// Gets the file system provider used by the pipeline.
     /// </summary>

--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -1,6 +1,7 @@
 using Hamelin.Steps;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Hamelin.Internal;
@@ -8,10 +9,12 @@ namespace Hamelin.Internal;
 /// <summary>
 /// The hosted service that runs the pipeline.
 /// </summary>
+/// <param name="logger">The logger for the pipeline host.</param>
 /// <param name="lifetime">The application lifetime.</param>
 /// <param name="scopeFactory">The factory that will be used to scope each execution of the pipeline.</param>
 /// <param name="options">Options to configure the pipeline execution</param>
 internal class PipelineHost(
+    ILogger<PipelineHost> logger,
     IHostApplicationLifetime lifetime,
     IServiceScopeFactory scopeFactory,
     IOptions<PipelineExecutionOptions> options
@@ -49,7 +52,25 @@ internal class PipelineHost(
                 return;
             }
 
-            await step.Run(cancellationToken);
+            try
+            {
+                await step.Run(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                switch (options.Value.TerminationMode)
+                {
+                    case PipelineTerminationMode.StopOnUnhandledException:
+                        logger.LogCritical(ex, "Unhandled error during pipeline execution.");
+                        lifetime.StopApplication();
+                        throw;
+                    case PipelineTerminationMode.StopAfterAllSteps:
+                        logger.LogError(ex, "Unhandled error during pipeline execution.");
+                        break;
+                    default:
+                        throw;
+                }
+            }
         }
     }
 }

--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -45,6 +45,11 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
             ContentRootPath = contentRoot,
             Configuration = configuration,
         });
+
+        _innerBuilder.Services
+            .Configure<HostOptions>(o => o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
+
+        _innerBuilder.Services.AddOptions<PipelineExecutionOptions>();
     }
 
     /// <inheritdoc />

--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -46,10 +46,12 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
             Configuration = configuration,
         });
 
+        // We have our own error handling in place for this.
         _innerBuilder.Services
             .Configure<HostOptions>(o => o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
 
-        _innerBuilder.Services.AddOptions<PipelineExecutionOptions>();
+        _innerBuilder.Services
+            .AddOptions<PipelineExecutionOptions>();
     }
 
     /// <inheritdoc />

--- a/src/Hamelin/PipelineExecutionOptions.cs
+++ b/src/Hamelin/PipelineExecutionOptions.cs
@@ -9,4 +9,9 @@ public class PipelineExecutionOptions
     /// If `true` then application termination will be requested the pipeline run is completed
     /// </summary>
     public bool StopApplicationOnCompletion { get; init; } = true;
+
+    /// <summary>
+    /// Controls what causes the pipeline to terminate early.
+    /// </summary>
+    public PipelineTerminationMode TerminationMode { get; set; } = PipelineTerminationMode.StopOnUnhandledException;
 }

--- a/src/Hamelin/PipelineTerminationMode.cs
+++ b/src/Hamelin/PipelineTerminationMode.cs
@@ -1,0 +1,17 @@
+namespace Hamelin;
+
+/// <summary>
+/// Describes the conditions under which the pipeline terminates early.
+/// </summary>
+public enum PipelineTerminationMode
+{
+    /// <summary>
+    /// The pipeline should terminate on the first unhandled exception.
+    /// </summary>
+    StopOnUnhandledException,
+
+    /// <summary>
+    /// The pipeline should only terminate after all steps have been run.
+    /// </summary>
+    StopAfterAllSteps
+}

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -101,4 +101,86 @@ public class PipelineHostTests
             step3.Run(Arg.Any<CancellationToken>());
         });
     }
+
+    [Fact]
+    public async Task StartAsync_WithStopOnUnhandledException_StopsOnUnhandledsException()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PipelineHost>>();
+        var lifetime = Substitute.For<IHostApplicationLifetime>();
+
+        var step1 = PipelineStepHelpers.CreateMock();
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+        var step3 = PipelineStepHelpers.CreateMock();
+
+        var provider = Substitute.For<IPipelineStepProvider>();
+        provider.GetSteps().Returns([step1, step2, step3]);
+
+        var services = new ServiceCollection()
+            .AddSingleton(provider)
+            .BuildServiceProvider();
+
+        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
+
+        PipelineExecutionOptions pipelineExecutionOptions = new()
+        {
+            TerminationMode = PipelineTerminationMode.StopOnUnhandledException
+        };
+
+        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+
+        // Assert
+        await act.ShouldThrowAsync<Exception>();
+        Received.InOrder(() =>
+        {
+            step1.Run(Arg.Any<CancellationToken>());
+            step2.Run(Arg.Any<CancellationToken>());
+        });
+        await step3.DidNotReceive().Run(Arg.Any<CancellationToken>());
+    }
+
+    [Fact] public async Task StartAsync_WithStopAfterAllSteps_StopsAfterAllSteps()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PipelineHost>>();
+        var lifetime = Substitute.For<IHostApplicationLifetime>();
+
+        var step1 = PipelineStepHelpers.CreateMock();
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+        var step3 = PipelineStepHelpers.CreateMock();
+
+        var provider = Substitute.For<IPipelineStepProvider>();
+        provider.GetSteps().Returns([step1, step2, step3]);
+
+        var services = new ServiceCollection()
+            .AddSingleton(provider)
+            .BuildServiceProvider();
+
+        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
+
+        PipelineExecutionOptions pipelineExecutionOptions = new()
+        {
+            TerminationMode = PipelineTerminationMode.StopAfterAllSteps
+        };
+
+        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldNotThrowAsync();
+        Received.InOrder(() =>
+        {
+            step1.Run(Arg.Any<CancellationToken>());
+            step2.Run(Arg.Any<CancellationToken>());
+            step3.Run(Arg.Any<CancellationToken>());
+        });
+    }
 }

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -3,6 +3,7 @@ using Hamelin.Steps;
 using Hamelin.Tests.Unit.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Hamelin.Tests.Unit.Internal;
@@ -13,6 +14,7 @@ public class PipelineHostTests
     public async Task StartAsync_WithStopApplicationOnCompletion_StopsApplicationWhenFinished()
     {
         // Arrange
+        var logger = Substitute.For<ILogger<PipelineHost>>();
         var lifetime = Substitute.For<IHostApplicationLifetime>();
 
         var provider = Substitute.For<IPipelineStepProvider>();
@@ -27,7 +29,7 @@ public class PipelineHostTests
             StopApplicationOnCompletion = true
         };
 
-        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -40,6 +42,7 @@ public class PipelineHostTests
     public async Task StartAsync_WithoutStopApplicationOnCompletion_DoesNotStopApplicationWhenFinished()
     {
         // Arrange
+        var logger = Substitute.For<ILogger<PipelineHost>>();
         var lifetime = Substitute.For<IHostApplicationLifetime>();
 
         var provider = Substitute.For<IPipelineStepProvider>();
@@ -54,7 +57,7 @@ public class PipelineHostTests
             StopApplicationOnCompletion = false
         };
 
-        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -67,6 +70,7 @@ public class PipelineHostTests
     public async Task StartAsync_WithSteps_RunsStepsInOrder()
     {
         // Arrange
+        var logger = Substitute.For<ILogger<PipelineHost>>();
         var lifetime = Substitute.For<IHostApplicationLifetime>();
 
         var step1 = PipelineStepHelpers.CreateMock();
@@ -84,7 +88,7 @@ public class PipelineHostTests
 
         PipelineExecutionOptions pipelineExecutionOptions = new();
 
-        var host = new PipelineHost(lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
 
         // Act
         await host.StartAsync(CancellationToken.None);

--- a/tests/Hamelin.Tests.Unit/Properties/Usings.cs
+++ b/tests/Hamelin.Tests.Unit/Properties/Usings.cs
@@ -1,3 +1,4 @@
 global using NSubstitute;
+global using NSubstitute.ExceptionExtensions;
 global using Shouldly;
 global using Xunit;


### PR DESCRIPTION
Adds a new `TerminationMode` property to the pipeline execution options that lets you control whether the pipeline terminates on unhandled exceptions or continues running.