### PR TITLE
Add Exit Code Support

### DIFF
--- a/src/Hamelin/IPipelineContext.cs
+++ b/src/Hamelin/IPipelineContext.cs
@@ -21,4 +21,10 @@ public interface IPipelineContext
     /// Gets the current working directory.
     /// </summary>
     string CurrentDirectory { get; }
+
+    /// <summary>
+    /// Gets or sets the exit code to use when the pipeline terminates.
+    /// If <c>null</c>, then Hamelin will determine the exit code, based on <see cref="PipelineExecutionOptions.EnableAutomaticExitCodes" />.
+    /// </summary>
+    int? ExitCode { get; set; }
 }

--- a/src/Hamelin/Internal/DefaultPipelineContext.cs
+++ b/src/Hamelin/Internal/DefaultPipelineContext.cs
@@ -7,4 +7,5 @@ internal class DefaultPipelineContext(IFileSystem fileSystem, IPipelineState sta
     public IFileSystem FileSystem { get; } = fileSystem;
     public IPipelineState State { get; } = state;
     public string CurrentDirectory => Environment.CurrentDirectory;
+    public int? ExitCode { get; set; }
 }

--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -33,7 +33,7 @@ internal class PipelineHost(
             // The only way we reach this is when the pipeline terminates early due to an unhandled error.
             if (options.Value.EnableAutomaticExitCodes)
             {
-                Environment.ExitCode = PipelineExitCodes.STOPPED_ON_ERROR;
+                Environment.ExitCode = PipelineExitCodes.StoppedOnError;
             }
             throw;
         }
@@ -55,12 +55,12 @@ internal class PipelineHost(
         var stepProvider = scope.ServiceProvider.GetRequiredService<IPipelineStepProvider>();
         var steps = stepProvider.GetSteps();
 
-        int automaticExitCode = PipelineExitCodes.SUCCESS;
+        int automaticExitCode = PipelineExitCodes.Success;
         foreach (var step in steps)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                automaticExitCode = PipelineExitCodes.STOPPED_AFTER_CANCEL;
+                automaticExitCode = PipelineExitCodes.StoppedAfterCancel;
                 break;
             }
 
@@ -74,7 +74,7 @@ internal class PipelineHost(
                 {
                     case PipelineTerminationMode.StopAfterAllSteps:
                         logger.LogError(ex, "Unhandled error during pipeline execution. Continuing...");
-                        automaticExitCode = PipelineExitCodes.CONTINUED_AFTER_ERROR;
+                        automaticExitCode = PipelineExitCodes.ContinuedAfterError;
                         break;
                     case PipelineTerminationMode.StopOnUnhandledException: // This is the default behaviour, so fall through to default case
                     default:
@@ -85,10 +85,10 @@ internal class PipelineHost(
             }
         }
 
-        if (options.Value.EnableAutomaticExitCodes && automaticExitCode != PipelineExitCodes.SUCCESS)
+        if (options.Value.EnableAutomaticExitCodes && automaticExitCode != PipelineExitCodes.Success)
         {
             return automaticExitCode;
         }
-        return context.ExitCode ?? PipelineExitCodes.SUCCESS;
+        return context.ExitCode ?? PipelineExitCodes.Success;
     }
 }

--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -25,7 +25,17 @@ internal class PipelineHost(
     {
         try
         {
-            await RunPipeline(cancellationToken);
+            int result = await RunPipeline(cancellationToken);
+            Environment.ExitCode = result;
+        }
+        catch (Exception)
+        {
+            // The only way we reach this is when the pipeline terminates early due to an unhandled error.
+            if (options.Value.EnableAutomaticExitCodes)
+            {
+                Environment.ExitCode = PipelineExitCodes.STOPPED_ON_ERROR;
+            }
+            throw;
         }
         finally
         {
@@ -37,19 +47,21 @@ internal class PipelineHost(
         }
     }
 
-    private async Task RunPipeline(CancellationToken cancellationToken)
+    private async Task<int> RunPipeline(CancellationToken cancellationToken)
     {
         // Resolve the steps from a scoped service provider.
         await using var scope = scopeFactory.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<IPipelineContext>();
         var stepProvider = scope.ServiceProvider.GetRequiredService<IPipelineStepProvider>();
         var steps = stepProvider.GetSteps();
 
-        // Run each step in the pipeline.
+        int automaticExitCode = PipelineExitCodes.SUCCESS;
         foreach (var step in steps)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return;
+                automaticExitCode = PipelineExitCodes.STOPPED_AFTER_CANCEL;
+                break;
             }
 
             try
@@ -62,6 +74,7 @@ internal class PipelineHost(
                 {
                     case PipelineTerminationMode.StopAfterAllSteps:
                         logger.LogError(ex, "Unhandled error during pipeline execution. Continuing...");
+                        automaticExitCode = PipelineExitCodes.CONTINUED_AFTER_ERROR;
                         break;
                     case PipelineTerminationMode.StopOnUnhandledException: // This is the default behaviour, so fall through to default case
                     default:
@@ -71,5 +84,11 @@ internal class PipelineHost(
                 }
             }
         }
+
+        if (options.Value.EnableAutomaticExitCodes && automaticExitCode != PipelineExitCodes.SUCCESS)
+        {
+            return automaticExitCode;
+        }
+        return context.ExitCode ?? PipelineExitCodes.SUCCESS;
     }
 }

--- a/src/Hamelin/PipelineExecutionOptions.cs
+++ b/src/Hamelin/PipelineExecutionOptions.cs
@@ -6,12 +6,17 @@ namespace Hamelin;
 public class PipelineExecutionOptions
 {
     /// <summary>
-    /// If `true` then application termination will be requested the pipeline run is completed
+    /// If `true` then application termination will be requested when the pipeline run is completed.
     /// </summary>
-    public bool StopApplicationOnCompletion { get; init; } = true;
+    public bool StopApplicationOnCompletion { get; set; } = true;
 
     /// <summary>
     /// Controls what causes the pipeline to terminate early.
     /// </summary>
     public PipelineTerminationMode TerminationMode { get; set; } = PipelineTerminationMode.StopOnUnhandledException;
+
+    /// <summary>
+    /// If `true` then the pipeline
+    /// </summary>
+    public bool EnableAutomaticExitCodes { get; set; } = true;
 }

--- a/src/Hamelin/PipelineExecutionOptions.cs
+++ b/src/Hamelin/PipelineExecutionOptions.cs
@@ -16,7 +16,7 @@ public class PipelineExecutionOptions
     public PipelineTerminationMode TerminationMode { get; set; } = PipelineTerminationMode.StopOnUnhandledException;
 
     /// <summary>
-    /// If `true` then the pipeline
+    /// If `true` then the pipeline will set the exit code automatically on failure.
     /// </summary>
     public bool EnableAutomaticExitCodes { get; set; } = true;
 }

--- a/src/Hamelin/PipelineExitCodes.cs
+++ b/src/Hamelin/PipelineExitCodes.cs
@@ -1,0 +1,9 @@
+namespace Hamelin;
+
+internal static class PipelineExitCodes
+{
+    public const int SUCCESS = 0;
+    public const int STOPPED_ON_ERROR = -1;
+    public const int CONTINUED_AFTER_ERROR = -2;
+    public const int STOPPED_AFTER_CANCEL = -3;
+}

--- a/src/Hamelin/PipelineExitCodes.cs
+++ b/src/Hamelin/PipelineExitCodes.cs
@@ -2,8 +2,8 @@ namespace Hamelin;
 
 internal static class PipelineExitCodes
 {
-    public const int SUCCESS = 0;
-    public const int STOPPED_ON_ERROR = -1;
-    public const int CONTINUED_AFTER_ERROR = -2;
-    public const int STOPPED_AFTER_CANCEL = -3;
+    public const int Success = 0;
+    public const int StoppedOnError = -1;
+    public const int ContinuedAfterError = -2;
+    public const int StoppedAfterCancel = -3;
 }

--- a/tests/Hamelin.Tests.Unit/Helpers/PipelineHostHelpers.cs
+++ b/tests/Hamelin.Tests.Unit/Helpers/PipelineHostHelpers.cs
@@ -1,0 +1,39 @@
+using Hamelin.Internal;
+using Hamelin.Steps;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Hamelin.Tests.Unit.Helpers;
+
+internal class PipelineHostHelpers
+{
+    public static PipelineHost CreateHost(
+        IPipelineStep[]? steps = null,
+        Action<PipelineExecutionOptions>? configure = null,
+        IPipelineContext? context = null,
+        IHostApplicationLifetime? lifetime = null,
+        ILogger<PipelineHost>? logger = null
+    )
+    {
+        logger ??= Substitute.For<ILogger<PipelineHost>>();
+        context ??= Substitute.For<IPipelineContext>();
+        lifetime ??= Substitute.For<IHostApplicationLifetime>();
+
+        var provider = Substitute.For<IPipelineStepProvider>();
+        provider.GetSteps().Returns(steps ?? []);
+
+        var services = new ServiceCollection()
+            .AddSingleton(provider)
+            .AddSingleton(context)
+            .BuildServiceProvider();
+
+        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
+
+        PipelineExecutionOptions pipelineExecutionOptions = new();
+        configure?.Invoke(pipelineExecutionOptions);
+
+        return new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+    }
+}

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -138,7 +138,7 @@ public class PipelineHostTests
 
         // Assert
         await step1.DidNotReceive().Run(Arg.Any<CancellationToken>());
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.STOPPED_AFTER_CANCEL);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.StoppedAfterCancel);
     }
 
     [Fact]
@@ -160,7 +160,7 @@ public class PipelineHostTests
 
         // Assert
         await act.ShouldThrowAsync<Exception>();
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.STOPPED_ON_ERROR);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.StoppedOnError);
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class PipelineHostTests
 
         // Assert
         await act.ShouldNotThrowAsync();
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.CONTINUED_AFTER_ERROR);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.ContinuedAfterError);
     }
 
     [Fact]
@@ -204,7 +204,7 @@ public class PipelineHostTests
 
         // Assert
         await step1.DidNotReceive().Run(Arg.Any<CancellationToken>());
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.SUCCESS);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.Success);
     }
 
     [Fact]
@@ -229,7 +229,7 @@ public class PipelineHostTests
 
         // Assert
         await act.ShouldThrowAsync<Exception>();
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.SUCCESS);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.Success);
     }
 
     [Fact]
@@ -254,7 +254,7 @@ public class PipelineHostTests
 
         // Assert
         await act.ShouldNotThrowAsync();
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.SUCCESS);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.Success);
     }
 
     [Fact]
@@ -310,6 +310,6 @@ public class PipelineHostTests
 
         // Assert
         await act.ShouldThrowAsync<Exception>();
-        Environment.ExitCode.ShouldBe(PipelineExitCodes.STOPPED_ON_ERROR);
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.StoppedOnError);
     }
 }

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -1,35 +1,25 @@
-using Hamelin.Internal;
-using Hamelin.Steps;
 using Hamelin.Tests.Unit.Helpers;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Hamelin.Tests.Unit.Internal;
 
 public class PipelineHostTests
 {
+    public PipelineHostTests()
+    {
+        Environment.ExitCode = 0;
+    }
+
     [Fact]
     public async Task StartAsync_WithStopApplicationOnCompletion_StopsApplicationWhenFinished()
     {
         // Arrange
-        var logger = Substitute.For<ILogger<PipelineHost>>();
         var lifetime = Substitute.For<IHostApplicationLifetime>();
 
-        var provider = Substitute.For<IPipelineStepProvider>();
-        var services = new ServiceCollection()
-            .AddSingleton(provider)
-            .BuildServiceProvider();
-
-        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
-
-        PipelineExecutionOptions pipelineExecutionOptions = new()
-        {
-            StopApplicationOnCompletion = true
-        };
-
-        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = PipelineHostHelpers.CreateHost(
+            configure: options => options.StopApplicationOnCompletion = true,
+            lifetime: lifetime
+        );
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -42,22 +32,12 @@ public class PipelineHostTests
     public async Task StartAsync_WithoutStopApplicationOnCompletion_DoesNotStopApplicationWhenFinished()
     {
         // Arrange
-        var logger = Substitute.For<ILogger<PipelineHost>>();
         var lifetime = Substitute.For<IHostApplicationLifetime>();
 
-        var provider = Substitute.For<IPipelineStepProvider>();
-        var services = new ServiceCollection()
-            .AddSingleton(provider)
-            .BuildServiceProvider();
-
-        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
-
-        PipelineExecutionOptions pipelineExecutionOptions = new()
-        {
-            StopApplicationOnCompletion = false
-        };
-
-        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = PipelineHostHelpers.CreateHost(
+            configure: options => options.StopApplicationOnCompletion = false,
+            lifetime: lifetime
+        );
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -70,25 +50,11 @@ public class PipelineHostTests
     public async Task StartAsync_WithSteps_RunsStepsInOrder()
     {
         // Arrange
-        var logger = Substitute.For<ILogger<PipelineHost>>();
-        var lifetime = Substitute.For<IHostApplicationLifetime>();
-
         var step1 = PipelineStepHelpers.CreateMock();
         var step2 = PipelineStepHelpers.CreateMock();
         var step3 = PipelineStepHelpers.CreateMock();
 
-        var provider = Substitute.For<IPipelineStepProvider>();
-        provider.GetSteps().Returns([step1, step2, step3]);
-
-        var services = new ServiceCollection()
-            .AddSingleton(provider)
-            .BuildServiceProvider();
-
-        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
-
-        PipelineExecutionOptions pipelineExecutionOptions = new();
-
-        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = PipelineHostHelpers.CreateHost([step1, step2, step3]);
 
         // Act
         await host.StartAsync(CancellationToken.None);
@@ -103,36 +69,21 @@ public class PipelineHostTests
     }
 
     [Fact]
-    public async Task StartAsync_WithStopOnUnhandledException_StopsOnUnhandledsException()
+    public async Task StartAsync_WithStopOnUnhandledException_StopsOnUnhandledException()
     {
         // Arrange
-        var logger = Substitute.For<ILogger<PipelineHost>>();
-        var lifetime = Substitute.For<IHostApplicationLifetime>();
-
         var step1 = PipelineStepHelpers.CreateMock();
         var step2 = PipelineStepHelpers.CreateMock();
         step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
         var step3 = PipelineStepHelpers.CreateMock();
 
-        var provider = Substitute.For<IPipelineStepProvider>();
-        provider.GetSteps().Returns([step1, step2, step3]);
-
-        var services = new ServiceCollection()
-            .AddSingleton(provider)
-            .BuildServiceProvider();
-
-        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
-
-        PipelineExecutionOptions pipelineExecutionOptions = new()
-        {
-            TerminationMode = PipelineTerminationMode.StopOnUnhandledException
-        };
-
-        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2, step3],
+            configure: options => options.TerminationMode = PipelineTerminationMode.StopOnUnhandledException
+        );
 
         // Act
         var act = () => host.StartAsync(CancellationToken.None);
-
 
         // Assert
         await act.ShouldThrowAsync<Exception>();
@@ -148,29 +99,15 @@ public class PipelineHostTests
     public async Task StartAsync_WithStopAfterAllSteps_StopsAfterAllSteps()
     {
         // Arrange
-        var logger = Substitute.For<ILogger<PipelineHost>>();
-        var lifetime = Substitute.For<IHostApplicationLifetime>();
-
         var step1 = PipelineStepHelpers.CreateMock();
         var step2 = PipelineStepHelpers.CreateMock();
         step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
         var step3 = PipelineStepHelpers.CreateMock();
 
-        var provider = Substitute.For<IPipelineStepProvider>();
-        provider.GetSteps().Returns([step1, step2, step3]);
-
-        var services = new ServiceCollection()
-            .AddSingleton(provider)
-            .BuildServiceProvider();
-
-        var scopeFactory = ServiceScopeHelpers.CreateScopeFactory(services);
-
-        PipelineExecutionOptions pipelineExecutionOptions = new()
-        {
-            TerminationMode = PipelineTerminationMode.StopAfterAllSteps
-        };
-
-        var host = new PipelineHost(logger, lifetime, scopeFactory, Options.Create(pipelineExecutionOptions));
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2, step3],
+            configure: options => options.TerminationMode = PipelineTerminationMode.StopAfterAllSteps
+        );
 
         // Act
         var act = () => host.StartAsync(CancellationToken.None);
@@ -183,5 +120,196 @@ public class PipelineHostTests
             step2.Run(Arg.Any<CancellationToken>());
             step3.Run(Arg.Any<CancellationToken>());
         });
+    }
+
+    [Fact]
+    public async Task StartAsync_AutoExitCodesAndTokenCancelled_SetsExitCodeToCancelled()
+    {
+        // Arrange
+        var step1 = PipelineStepHelpers.CreateMock();
+
+        var host = PipelineHostHelpers.CreateHost([step1]);
+
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act
+        await host.StartAsync(cts.Token);
+
+        // Assert
+        await step1.DidNotReceive().Run(Arg.Any<CancellationToken>());
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.STOPPED_AFTER_CANCEL);
+    }
+
+    [Fact]
+    public async Task StartAsync_AutoExitCodesAndStopOnUnhandledException_SetsExitCodeToStoppedOnError()
+    {
+        // Arrange
+        var step1 = PipelineStepHelpers.CreateMock();
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+        var step3 = PipelineStepHelpers.CreateMock();
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2, step3],
+            configure: options => options.TerminationMode = PipelineTerminationMode.StopOnUnhandledException
+        );
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldThrowAsync<Exception>();
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.STOPPED_ON_ERROR);
+    }
+
+    [Fact]
+    public async Task StartAsync_AutoExitCodesAndStopAfterAllSteps_SetsExitCodeToContinuedAfterError()
+    {
+        // Arrange
+        var step1 = PipelineStepHelpers.CreateMock();
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+        var step3 = PipelineStepHelpers.CreateMock();
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2, step3],
+            configure: options => options.TerminationMode = PipelineTerminationMode.StopAfterAllSteps
+        );
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldNotThrowAsync();
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.CONTINUED_AFTER_ERROR);
+    }
+
+    [Fact]
+    public async Task StartAsync_NoAutoExitCodesAndTokenCancelled_DoesNotSetExitCode()
+    {
+        // Arrange
+        var step1 = PipelineStepHelpers.CreateMock();
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1],
+            options => options.EnableAutomaticExitCodes = false
+        );
+
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act
+        await host.StartAsync(cts.Token);
+
+        // Assert
+        await step1.DidNotReceive().Run(Arg.Any<CancellationToken>());
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.SUCCESS);
+    }
+
+    [Fact]
+    public async Task StartAsync_NoAutoExitCodesAndStopOnUnhandledException_DoesNotSetExitCode()
+    {
+        // Arrange
+        var step1 = PipelineStepHelpers.CreateMock();
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+        var step3 = PipelineStepHelpers.CreateMock();
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2, step3],
+            configure: options =>
+            {
+                options.EnableAutomaticExitCodes = false;
+                options.TerminationMode = PipelineTerminationMode.StopOnUnhandledException;
+            });
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldThrowAsync<Exception>();
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.SUCCESS);
+    }
+
+    [Fact]
+    public async Task StartAsync_NoAutoExitCodesAndStopAfterAllSteps_DoesNotSetExitCode()
+    {
+        // Arrange
+        var step1 = PipelineStepHelpers.CreateMock();
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+        var step3 = PipelineStepHelpers.CreateMock();
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2, step3],
+            configure: options =>
+            {
+                options.EnableAutomaticExitCodes = false;
+                options.TerminationMode = PipelineTerminationMode.StopAfterAllSteps;
+            });
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldNotThrowAsync();
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.SUCCESS);
+    }
+
+    [Fact]
+    public async Task StartAsync_CustomExitCode_SetsExitCodeToCustomExitCode()
+    {
+        // Arrange
+        var context = Substitute.For<IPipelineContext>();
+
+        var step1 = PipelineStepHelpers.CreateMock();
+        step1
+            .When(s => s.Run(Arg.Any<CancellationToken>()))
+            .Do((i) =>
+            {
+                context.ExitCode = 1234;
+            });
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1],
+            context: context
+        );
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldNotThrowAsync();
+        Environment.ExitCode.ShouldBe(1234);
+    }
+
+    [Fact]
+    public async Task StartAsync_CustomExitCode_DoesNotOverrideAutomaticCode()
+    {
+        // Arrange
+        var context = Substitute.For<IPipelineContext>();
+
+        var step1 = PipelineStepHelpers.CreateMock();
+        step1
+            .When(s => s.Run(Arg.Any<CancellationToken>()))
+            .Do((i) =>
+            {
+                context.ExitCode = 1234;
+            });
+        var step2 = PipelineStepHelpers.CreateMock();
+        step2.Run(Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test"));
+
+        var host = PipelineHostHelpers.CreateHost(
+            steps: [step1, step2],
+            context: context
+        );
+
+        // Act
+        var act = () => host.StartAsync(CancellationToken.None);
+
+        // Assert
+        await act.ShouldThrowAsync<Exception>();
+        Environment.ExitCode.ShouldBe(PipelineExitCodes.STOPPED_ON_ERROR);
     }
 }


### PR DESCRIPTION
## Automatic exit codes
- Automatic exit codes are enabled by default and can be disabled on the `PipelineExecutionOptions`.
- When enabled, the exit code will be set automatically when the pipeline ends based on the following conditions:
  - If the cancellation token was cancelled.
  - If an unhandled exception was thrown (and the termination mode is 'stop on unhandled exception')
  - If an unhandled exception was thrown (and the termination mode is 'stop after all steps').

## Custom exit codes
- There is a new `ExitCode` property on `IPipelineContext` that when set, allows the developer to override the environment exit code after the pipeline has finished execution.
- When automatic exit codes are enabled, any error should override the custom exit code.

## Other changes
- Refactored the `PipelineHostTests` to use a helper method to create the host.