### PR TITLE
Fix Version Number

### DIFF
--- a/src/Hamelin/Hamelin.csproj
+++ b/src/Hamelin/Hamelin.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Previous PR bumped the version from `0.0.2` to `0.0.3`, but `0.0.2` hadn't been released yet.

Previous PR also introduced new features though, so `0.1.0` sees more appropriate.