### PR TITLE
Validate version increment

### DIFF
--- a/build/Hamelin.Build/Hamelin.Build.csproj
+++ b/build/Hamelin.Build/Hamelin.Build.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
       <PackageReference Include="CliWrap" Version="3.9.0" />
-      <PackageReference Include="Hamelin.Runtimes.GitHubActions" Version="0.0.3" />
+      <PackageReference Include="Hamelin.Runtimes.GitHubActions" Version="0.0.4" />
       <PackageReference Include="NuGet.Packaging" Version="6.14.0" />
       <PackageReference Include="NuGet.Protocol" Version="6.14.0" />
     </ItemGroup>

--- a/build/Hamelin.Build/Steps/VersionStep.cs
+++ b/build/Hamelin.Build/Steps/VersionStep.cs
@@ -10,7 +10,7 @@ using NuGet.Versioning;
 namespace Hamelin.Build.Steps;
 
 public class VersionStep(
-    ILoggerFactory loggerFactory,
+    ILogger<VersionStep> logger,
     IOptions<BuildOptions> options,
     IPipelineContext context
 ) : IPipelineStep
@@ -27,17 +27,64 @@ public class VersionStep(
         var packageSource = new PackageSource(options.Value.NuGetFeed) { Credentials = credentials };
         SourceRepository repository = Repository.Factory.GetCoreV3(packageSource);
         var resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
-        IEnumerable<NuGetVersion> versions = await resource.GetAllVersionsAsync(
+        var versions = (await resource.GetAllVersionsAsync(
             projectInfo.Name,
             new SourceCacheContext(),
-            new NuGetLoggerAdapter(loggerFactory.CreateLogger<FindPackageByIdResource>()),
+            new NuGetLoggerAdapter(logger),
             cancellationToken
-        );
+        )).ToList();
+
+        if (versions.Count == 0)
+        {
+            logger.LogInformation("No existing versions found for package {PackageName}.", projectInfo.Name);
+            if (projectInfo.Version != NuGetVersion.Parse("0.0.1"))
+            {
+                throw new Exception(
+                    $"No existing versions found for package {projectInfo.Name}. The first version must be 0.0.1.");
+            }
+        }
 
         NuGetVersion? match = versions.FirstOrDefault(c => c == projectInfo.Version);
         if (match != null)
         {
             throw new Exception("Package version already exists.");
+        }
+
+        var latestVersion = versions.Max(v => v) ?? versions.Last();
+        Queue<int> versionParts = new([projectInfo.Version.Major, projectInfo.Version.Minor, projectInfo.Version.Patch, projectInfo.Version.Revision]);
+        Queue<int> latestVersionParts = new([latestVersion.Major, latestVersion.Minor, latestVersion.Patch, latestVersion.Revision]);
+
+        while (versionParts.Count != 0)
+        {
+            int part = versionParts.Dequeue();
+            int latestPart = latestVersionParts.Dequeue();
+
+            if (part < latestPart)
+            {
+                throw new Exception(
+                    $"Project version {projectInfo.Version} is not greater than the latest version {latestVersion}.");
+            }
+
+            if (part > latestPart + 1)
+            {
+                throw new Exception(
+                    $"Project version {projectInfo.Version} is not a valid increment of the latest version {latestVersion}.");
+            }
+
+            if (part == latestPart + 1)
+            {
+                // If we are incrementing the version, we can stop checking further parts
+                break;
+            }
+        }
+
+        while (versionParts.Count != 0)
+        {
+            int part = versionParts.Dequeue();
+            if (part != 0)
+            {
+                throw new Exception("When incrementing a version number, all remaining version parts must be 0.");
+            }
         }
     }
 }

--- a/tests/Hamelin.Tests.Unit/Hamelin.Tests.Unit.csproj
+++ b/tests/Hamelin.Tests.Unit/Hamelin.Tests.Unit.csproj
@@ -16,11 +16,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" Version="4.3.0"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.0.0"/>
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds a build check that enforces NuGet package versions only go up by one each time, and that any other version parts reset to 0.