### PR TITLE
Refactor Pipeline Runner

### DIFF
--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -54,31 +54,39 @@ internal class PipelineHost(
         var context = scope.ServiceProvider.GetRequiredService<IPipelineContext>();
         var stepProvider = scope.ServiceProvider.GetRequiredService<IPipelineStepProvider>();
         var steps = stepProvider.GetSteps();
+        var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
 
         int automaticExitCode = PipelineExitCodes.Success;
         foreach (var step in steps)
         {
             if (cancellationToken.IsCancellationRequested)
             {
+                logger.LogInformation("Pipeline execution cancelled. Stopping execution of remaining steps.");
                 automaticExitCode = PipelineExitCodes.StoppedAfterCancel;
                 break;
             }
 
+            var stepType = step.GetType();
+            string stepName = stepType.Name;
+            var stepLogger = loggerFactory.CreateLogger(stepType);
+
             try
             {
+                stepLogger.LogInformation("Running {StepName}", stepName);
                 await step.Run(cancellationToken);
+                stepLogger.LogInformation("{StepName} completed successfully.", stepName);
             }
             catch (Exception ex)
             {
                 switch (options.Value.TerminationMode)
                 {
                     case PipelineTerminationMode.StopAfterAllSteps:
-                        logger.LogError(ex, "Unhandled error during pipeline execution. Continuing...");
+                        stepLogger.LogError(ex, "Unhandled error during pipeline execution of step {StepName}. Continuing...", stepName);
                         automaticExitCode = PipelineExitCodes.ContinuedAfterError;
                         break;
                     case PipelineTerminationMode.StopOnUnhandledException: // This is the default behaviour, so fall through to default case
                     default:
-                        logger.LogCritical(ex, "Unhandled error during pipeline execution. Exiting.");
+                        stepLogger.LogCritical(ex, "Unhandled error during pipeline execution of step {StepName}. Exiting.", stepName);
                         lifetime.StopApplication();
                         throw;
                 }

--- a/src/Hamelin/Internal/PipelineHost.cs
+++ b/src/Hamelin/Internal/PipelineHost.cs
@@ -25,17 +25,8 @@ internal class PipelineHost(
     {
         try
         {
-            int result = await RunPipeline(cancellationToken);
-            Environment.ExitCode = result;
-        }
-        catch (Exception)
-        {
-            // The only way we reach this is when the pipeline terminates early due to an unhandled error.
-            if (options.Value.EnableAutomaticExitCodes)
-            {
-                Environment.ExitCode = PipelineExitCodes.StoppedOnError;
-            }
-            throw;
+            var summary = await RunPipeline(cancellationToken);
+            Environment.ExitCode = summary.ExitCode;
         }
         finally
         {
@@ -47,56 +38,63 @@ internal class PipelineHost(
         }
     }
 
-    private async Task<int> RunPipeline(CancellationToken cancellationToken)
+    private async Task<PipelineExecutionSummary> RunPipeline(CancellationToken cancellationToken)
     {
         // Resolve the steps from a scoped service provider.
         await using var scope = scopeFactory.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<IPipelineContext>();
+
+        var results = await RunSteps(scope, cancellationToken);
+        var summary = new PipelineExecutionSummary(options, context, results, cancellationToken);
+        return summary;
+    }
+
+    private async Task<IEnumerable<PipelineStepResult>> RunSteps(AsyncServiceScope scope, CancellationToken cancellationToken)
+    {
+        List<PipelineStepResult> results = [];
         var stepProvider = scope.ServiceProvider.GetRequiredService<IPipelineStepProvider>();
         var steps = stepProvider.GetSteps();
-        var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
-
-        int automaticExitCode = PipelineExitCodes.Success;
         foreach (var step in steps)
         {
-            if (cancellationToken.IsCancellationRequested)
+            var result = await RunStep(step, cancellationToken);
+            results.Add(result);
+            if (!result.Continue)
             {
-                logger.LogInformation("Pipeline execution cancelled. Stopping execution of remaining steps.");
-                automaticExitCode = PipelineExitCodes.StoppedAfterCancel;
                 break;
             }
-
-            var stepType = step.GetType();
-            string stepName = stepType.Name;
-            var stepLogger = loggerFactory.CreateLogger(stepType);
-
-            try
-            {
-                stepLogger.LogInformation("Running {StepName}", stepName);
-                await step.Run(cancellationToken);
-                stepLogger.LogInformation("{StepName} completed successfully.", stepName);
-            }
-            catch (Exception ex)
-            {
-                switch (options.Value.TerminationMode)
-                {
-                    case PipelineTerminationMode.StopAfterAllSteps:
-                        stepLogger.LogError(ex, "Unhandled error during pipeline execution of step {StepName}. Continuing...", stepName);
-                        automaticExitCode = PipelineExitCodes.ContinuedAfterError;
-                        break;
-                    case PipelineTerminationMode.StopOnUnhandledException: // This is the default behaviour, so fall through to default case
-                    default:
-                        stepLogger.LogCritical(ex, "Unhandled error during pipeline execution of step {StepName}. Exiting.", stepName);
-                        lifetime.StopApplication();
-                        throw;
-                }
-            }
         }
 
-        if (options.Value.EnableAutomaticExitCodes && automaticExitCode != PipelineExitCodes.Success)
+        return results.ToArray();
+    }
+
+    private async Task<PipelineStepResult> RunStep(IPipelineStep step, CancellationToken cancellationToken)
+    {
+        var stepType = step.GetType();
+        string stepName = stepType.Name;
+
+        if (cancellationToken.IsCancellationRequested)
         {
-            return automaticExitCode;
+            return PipelineStepResult.StoppedAfterCancel;
         }
-        return context.ExitCode ?? PipelineExitCodes.Success;
+
+        try
+        {
+            await step.Run(cancellationToken);
+            return PipelineStepResult.Successful;
+        }
+        catch (Exception ex)
+        {
+            switch (options.Value.TerminationMode)
+            {
+                case PipelineTerminationMode.StopAfterAllSteps:
+                    logger.LogError(ex, "Unhandled error during pipeline execution of step {StepName}. Continuing...", stepName);
+                    return PipelineStepResult.ContinuedAfterError(ex);
+                case PipelineTerminationMode.StopOnUnhandledException: // This is the default behaviour, so fall through to default case
+                default:
+                    logger.LogCritical(ex, "Unhandled error during pipeline execution of step {StepName}. Exiting.", stepName);
+                    lifetime.StopApplication();
+                    return PipelineStepResult.StoppedOnError(ex);
+            }
+        }
     }
 }

--- a/src/Hamelin/PipelineExecutionSummary.cs
+++ b/src/Hamelin/PipelineExecutionSummary.cs
@@ -1,0 +1,55 @@
+using System.Collections.ObjectModel;
+using Microsoft.Extensions.Options;
+
+namespace Hamelin;
+
+/// <summary>
+/// Represents the summary of a pipeline execution, including the exit code and results of each step.
+/// </summary>
+public class PipelineExecutionSummary
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="PipelineExecutionSummary"/>.
+    /// </summary>
+    public PipelineExecutionSummary(
+        IOptions<PipelineExecutionOptions> options,
+        IPipelineContext context,
+        IEnumerable<PipelineStepResult> steps,
+        CancellationToken cancellationToken
+    )
+    {
+        var stepList = steps.ToList().AsReadOnly();
+        ExitCode = CalculateExitCode(options, context, stepList, cancellationToken);
+        Steps = stepList;
+    }
+
+    /// <summary>
+    /// Gets the exit code of the overall pipeline execution.
+    /// </summary>
+    public int ExitCode { get; }
+
+    /// <summary>
+    /// Gets the results of each step in the pipeline execution.
+    /// </summary>
+    public IReadOnlyCollection<PipelineStepResult> Steps { get; init; }
+
+    private static int CalculateExitCode(IOptions<PipelineExecutionOptions> options, IPipelineContext context, ReadOnlyCollection<PipelineStepResult> steps, CancellationToken cancellationToken)
+    {
+        int autoCode = steps.LastOrDefault()?.ExitCode ?? PipelineExitCodes.Success;
+        if (autoCode == PipelineExitCodes.Success && steps.Any(r => r.ExitCode == PipelineExitCodes.ContinuedAfterError))
+        {
+            autoCode = PipelineExitCodes.ContinuedAfterError;
+        }
+        else if (steps.Count == 0 && cancellationToken.IsCancellationRequested)
+        {
+            autoCode = PipelineExitCodes.StoppedAfterCancel;
+        }
+
+        if (options.Value.EnableAutomaticExitCodes && autoCode != PipelineExitCodes.Success)
+        {
+            return autoCode;
+        }
+
+        return context.ExitCode ?? PipelineExitCodes.Success;
+    }
+}

--- a/src/Hamelin/PipelineStepResult.cs
+++ b/src/Hamelin/PipelineStepResult.cs
@@ -1,0 +1,34 @@
+namespace Hamelin;
+
+/// <summary>
+/// Represents the result of a pipeline step execution.
+/// </summary>
+/// <param name="ExitCode">The exit code of the individual step.</param>
+/// <param name="Continue">True if the pipeline should continue execution, otherwise false.</param>
+/// <param name="Exception">The exception that was thrown by the pipeline step.</param>
+public record PipelineStepResult(int ExitCode, bool Continue, Exception? Exception)
+{
+    /// <summary>
+    /// Represents a successful pipeline step execution with no exceptions and continuation.
+    /// </summary>
+    public static readonly PipelineStepResult Successful = new(PipelineExitCodes.Success, true, null);
+
+    /// <summary>
+    /// Indicates that cancellation was requested, and the pipeline should stop execution.s
+    /// </summary>
+    public static readonly PipelineStepResult StoppedAfterCancel = new(PipelineExitCodes.StoppedAfterCancel, false, null);
+
+    /// <summary>
+    /// Indicates that the pipeline step resulted in an error, but the pipeline should continue execution.
+    /// </summary>
+    /// <param name="ex">The exception that was thrown.</param>
+    /// <returns>The result.</returns>
+    public static PipelineStepResult ContinuedAfterError(Exception ex) => new(PipelineExitCodes.ContinuedAfterError, true, ex);
+
+    /// <summary>
+    /// Indicates that the pipeline step resulted in an error, and the pipeline should stop execution.
+    /// </summary>
+    /// <param name="ex">The exception that was thrown.</param>
+    /// <returns>The result.</returns>
+    public static PipelineStepResult StoppedOnError(Exception ex) => new(PipelineExitCodes.StoppedOnError, false, ex);
+}

--- a/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
+++ b/tests/Hamelin.Tests.Unit/Internal/PipelineHostTests.cs
@@ -83,10 +83,9 @@ public class PipelineHostTests
         );
 
         // Act
-        var act = () => host.StartAsync(CancellationToken.None);
+        await host.StartAsync(CancellationToken.None);
 
         // Assert
-        await act.ShouldThrowAsync<Exception>();
         Received.InOrder(() =>
         {
             step1.Run(Arg.Any<CancellationToken>());
@@ -156,10 +155,9 @@ public class PipelineHostTests
         );
 
         // Act
-        var act = () => host.StartAsync(CancellationToken.None);
+        await host.StartAsync(CancellationToken.None);
 
         // Assert
-        await act.ShouldThrowAsync<Exception>();
         Environment.ExitCode.ShouldBe(PipelineExitCodes.StoppedOnError);
     }
 
@@ -225,10 +223,9 @@ public class PipelineHostTests
             });
 
         // Act
-        var act = () => host.StartAsync(CancellationToken.None);
+        await host.StartAsync(CancellationToken.None);
 
         // Assert
-        await act.ShouldThrowAsync<Exception>();
         Environment.ExitCode.ShouldBe(PipelineExitCodes.Success);
     }
 
@@ -306,10 +303,9 @@ public class PipelineHostTests
         );
 
         // Act
-        var act = () => host.StartAsync(CancellationToken.None);
+        await host.StartAsync(CancellationToken.None);
 
         // Assert
-        await act.ShouldThrowAsync<Exception>();
         Environment.ExitCode.ShouldBe(PipelineExitCodes.StoppedOnError);
     }
 }


### PR DESCRIPTION
Refactors the pipeline runner to be more flexible:
- Each step is run inside a self-contained `RunStep` function making it easier to reason about.
- `RunSteps` is responsible for wrangling all the steps and deciding when to break/continue.
- `RunPipeline` is responsible for running the steps and compiling a summary.
- `Computing the `ExitCode` is now done in one place based on all the summary information, making it easier to test in isolation, and easier to reason about as it doesn't change throughout the pipeline execution.

The big breaking change with this approach is that when stopping on error, the exception isn't thrown, because then that breaks all of the step summary info. It's not great if we lose all our output because of an unhandled exception. Considering the context in which Hamelin will be used, I think it's okay for us to just log the exception and ensure the exit code is set correctly. 