### PR TITLE
Add default custom console log formatter

### DIFF
--- a/build/Hamelin.Build/Helpers/NuGetLoggerAdapter.cs
+++ b/build/Hamelin.Build/Helpers/NuGetLoggerAdapter.cs
@@ -16,7 +16,7 @@ public class NuGetLoggerAdapter(ILogger logger) : NuGet.Common.ILogger
     public void LogError(string data) => logger.LogWarning(data);
     public void LogInformationSummary(string data) => logger.LogInformation(data);
 
-    public void Log(LogLevel level, string data) =>  logger.Log(level switch
+    public void Log(LogLevel level, string data) => logger.Log(level switch
     {
         LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
         LogLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Trace,

--- a/build/Hamelin.Build/Program.cs
+++ b/build/Hamelin.Build/Program.cs
@@ -8,8 +8,6 @@ using Microsoft.Extensions.Hosting;
 
 var builder = PipelineApplication.CreateBuilder(args);
 
-builder.Logging.AddPipelineConsoleFormatter();
-
 builder.Services
     .AddScoped<ICommandRunner, CliWrapCommandRunner>()
     .AddGitHubActionsRuntime()

--- a/build/Hamelin.Build/Program.cs
+++ b/build/Hamelin.Build/Program.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Hosting;
 
 var builder = PipelineApplication.CreateBuilder(args);
 
+builder.Logging.AddPipelineConsoleFormatter();
+
 builder.Services
     .AddScoped<ICommandRunner, CliWrapCommandRunner>()
     .AddGitHubActionsRuntime()

--- a/build/Hamelin.Build/appsettings.json
+++ b/build/Hamelin.Build/appsettings.json
@@ -9,7 +9,12 @@
     "Logging": {
         "LogLevel": {
             "Default": "Debug"
+        },
+        "Console": {
+            "FormatterOptions": {
+                "TimestampFormat": "HH:mm:ss",
+                "ColorBehavior": "Default"
+            }
         }
-    },
-    "Mode": "PullRequest"
+    }
 }

--- a/build/Hamelin.Build/appsettings.json
+++ b/build/Hamelin.Build/appsettings.json
@@ -5,5 +5,11 @@
         "Configuration": "Release",
         "ProjectFile": "src/Hamelin/Hamelin.csproj",
         "NuGetFeed": "https://api.nuget.org/v3/index.json"
-    }
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Debug"
+        }
+    },
+    "Mode": "PullRequest"
 }

--- a/src/Hamelin/Extensions/ConsoleFormatterExtensions.cs
+++ b/src/Hamelin/Extensions/ConsoleFormatterExtensions.cs
@@ -1,0 +1,30 @@
+using Hamelin.Logging;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Hamelin;
+
+/// <summary>
+/// Provides extension methods for registering console log formatters.
+/// </summary>
+public static class ConsoleFormatterExtensions
+{
+    /// <summary>
+    /// Adds the pipeline friendly log formatter to the builder with the specified configuration.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="configure"></param>
+    public static ILoggingBuilder AddPipelineConsoleFormatter(
+        this ILoggingBuilder builder,
+        Action<PipelineConsoleFormatterOptions> configure) =>
+        builder.AddConsole(options => options.FormatterName = PipelineConsoleFormatter.FormatterName)
+            .AddConsoleFormatter<PipelineConsoleFormatter, PipelineConsoleFormatterOptions>(configure);
+
+    /// <summary>
+    /// Adds the pipeline friendly log formatter to the builder.
+    /// </summary>
+    /// <param name="builder"></param>
+    public static ILoggingBuilder AddPipelineConsoleFormatter(this ILoggingBuilder builder) =>
+        builder.AddConsole(options => options.FormatterName = PipelineConsoleFormatter.FormatterName)
+            .AddConsoleFormatter<PipelineConsoleFormatter, PipelineConsoleFormatterOptions>();
+}

--- a/src/Hamelin/Extensions/PipelineStepExtensions.cs
+++ b/src/Hamelin/Extensions/PipelineStepExtensions.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using System.Reflection;
+
+// ReSharper disable once CheckNamespace
+namespace Hamelin;
+
+/// <summary>
+/// Provides extensions for working with <see cref="IPipelineStep"/>
+/// </summary>
+public static class PipelineStepExtensions
+{
+    /// <summary>
+    /// Gets the display name of the step
+    /// </summary>
+    /// <param name="step">The step to get the name from</param>
+    /// <returns>The contents of the <see cref="DisplayNameAttribute"/> on the step's class, or the class name if no display name is available.</returns>
+    public static string GetDisplayName(this IPipelineStep step)
+    {
+        var displayNameAttribute = (DisplayNameAttribute?)step.GetType().GetCustomAttribute(typeof(DisplayNameAttribute));
+
+        return displayNameAttribute?.DisplayName ?? step.GetType().Name;
+    }
+}

--- a/src/Hamelin/Hamelin.csproj
+++ b/src/Hamelin/Hamelin.csproj
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,7 +31,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.8.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/Hamelin/Hamelin.csproj
+++ b/src/Hamelin/Hamelin.csproj
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.8.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/Hamelin/Internal/DefaultPipelineRunner.cs
+++ b/src/Hamelin/Internal/DefaultPipelineRunner.cs
@@ -35,7 +35,7 @@ internal class DefaultPipelineRunner(
         var hooks = scope.ServiceProvider.GetServices<IPrePipelineHook>().ToList();
         if (hooks.Count == 0)
         {
-            logger.LogInformation("No pre-pipeline hooks registered.");
+            logger.LogDebug("No pre-pipeline hooks registered.");
             return;
         }
 
@@ -66,7 +66,7 @@ internal class DefaultPipelineRunner(
         var hooks = scope.ServiceProvider.GetServices<IPostPipelineHook>().ToList();
         if (hooks.Count == 0)
         {
-            logger.LogInformation("No post-pipeline hooks registered.");
+            logger.LogDebug("No post-pipeline hooks registered.");
             return;
         }
 

--- a/src/Hamelin/Internal/DefaultPipelineRunner.cs
+++ b/src/Hamelin/Internal/DefaultPipelineRunner.cs
@@ -101,7 +101,7 @@ internal class DefaultPipelineRunner(
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                summaries.Add(StepExecutionSummary.FromStep(step, PipelineStepResult.StoppedAfterCancel));
+                summaries.Add(new StepExecutionSummary(step.GetDisplayName(), PipelineStepResult.StoppedAfterCancel));
                 break;
             }
 

--- a/src/Hamelin/Internal/DefaultPipelineStepRunner.cs
+++ b/src/Hamelin/Internal/DefaultPipelineStepRunner.cs
@@ -13,19 +13,21 @@ internal class DefaultPipelineStepRunner(
 {
     public async Task<StepExecutionSummary> RunStep(AsyncServiceScope scope, IPipelineStep step, CancellationToken cancellationToken)
     {
-        var attribs = new LogAttributes { StepName = step.GetType().Name };
+        string displayName = step.GetDisplayName();
+
+        var attribs = new LogAttributes { StepName = displayName };
         using var loggingScope = logger.BeginScope(attribs);
 
         if (cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation("Aborting pipeline step due to cancellation request.");
-            return StepExecutionSummary.FromStep(step, PipelineStepResult.StoppedAfterCancel);
+            return new StepExecutionSummary(displayName, PipelineStepResult.StoppedAfterCancel);
         }
 
         await RunPreStepHooks(scope);
 
         var result = await RunStepCore(step, cancellationToken);
-        var summary = StepExecutionSummary.FromStep(step, result);
+        var summary = new StepExecutionSummary(displayName, result);
 
         await RunPostStepHooks(scope, summary);
 

--- a/src/Hamelin/Internal/DefaultPipelineStepRunner.cs
+++ b/src/Hamelin/Internal/DefaultPipelineStepRunner.cs
@@ -1,4 +1,5 @@
 using Hamelin.Hooks;
+using Hamelin.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -12,6 +13,9 @@ internal class DefaultPipelineStepRunner(
 {
     public async Task<StepExecutionSummary> RunStep(AsyncServiceScope scope, IPipelineStep step, CancellationToken cancellationToken)
     {
+        var attribs = new LogAttributes { StepName = step.GetType().Name };
+        using var loggingScope = logger.BeginScope(attribs);
+
         if (cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation("Aborting pipeline step due to cancellation request.");

--- a/src/Hamelin/Logging/AnsiParser.cs
+++ b/src/Hamelin/Logging/AnsiParser.cs
@@ -1,0 +1,214 @@
+// This is a copy of the .Net internal AnsiParser class used in Microsoft.Extensions.Logging.Console
+// https://github.com/dotnet/runtime/blob/release/8.0/src/libraries/Microsoft.Extensions.Logging.Console/src/AnsiParser.cs
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Hamelin.Logging;
+
+internal sealed class AnsiParser
+{
+    private readonly Action<string, int, int, ConsoleColor?, ConsoleColor?> _onParseWrite;
+
+    public AnsiParser(Action<string, int, int, ConsoleColor?, ConsoleColor?> onParseWrite)
+    {
+        ArgumentNullException.ThrowIfNull(onParseWrite);
+
+        _onParseWrite = onParseWrite;
+    }
+
+    /// <summary>
+    /// Parses a subset of display attributes
+    /// Set Display Attributes
+    /// Set Attribute Mode [{attr1};...;{attrn}m
+    /// Sets multiple display attribute settings. The following lists standard attributes that are getting parsed:
+    /// 1 Bright
+    /// Foreground Colours
+    /// 30 Black
+    /// 31 Red
+    /// 32 Green
+    /// 33 Yellow
+    /// 34 Blue
+    /// 35 Magenta
+    /// 36 Cyan
+    /// 37 White
+    /// Background Colours
+    /// 40 Black
+    /// 41 Red
+    /// 42 Green
+    /// 43 Yellow
+    /// 44 Blue
+    /// 45 Magenta
+    /// 46 Cyan
+    /// 47 White
+    /// </summary>
+    public void Parse(string message)
+    {
+        int startIndex = -1;
+        int length = 0;
+        ConsoleColor? foreground = null;
+        ConsoleColor? background = null;
+        var span = message.AsSpan();
+        const char escapeChar = '\u001b';
+        bool isBright = false;
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (span[i] == escapeChar && span.Length >= i + 4 && span[i + 1] == '[')
+            {
+                int escapeCode;
+                if (span[i + 3] == 'm')
+                {
+                    // Example: \u001b[1m
+                    if (IsDigit(span[i + 2]))
+                    {
+                        escapeCode = span[i + 2] - '0';
+                        if (startIndex != -1)
+                        {
+                            _onParseWrite(message, startIndex, length, background, foreground);
+                            startIndex = -1;
+                            length = 0;
+                        }
+
+                        if (escapeCode == 1)
+                            isBright = true;
+                        i += 3;
+                        continue;
+                    }
+                }
+                else if (span.Length >= i + 5 && span[i + 4] == 'm')
+                {
+                    // Example: \u001b[40m
+                    if (IsDigit(span[i + 2]) && IsDigit(span[i + 3]))
+                    {
+                        escapeCode = (span[i + 2] - '0') * 10 + (span[i + 3] - '0');
+                        if (startIndex != -1)
+                        {
+                            _onParseWrite(message, startIndex, length, background, foreground);
+                            startIndex = -1;
+                            length = 0;
+                        }
+
+                        if (TryGetForegroundColor(escapeCode, isBright, out ConsoleColor? color))
+                        {
+                            foreground = color;
+                            isBright = false;
+                        }
+                        else if (TryGetBackgroundColor(escapeCode, out color))
+                        {
+                            background = color;
+                        }
+
+                        i += 4;
+                        continue;
+                    }
+                }
+            }
+
+            if (startIndex == -1)
+            {
+                startIndex = i;
+            }
+
+            int nextEscapeIndex = -1;
+            if (i < message.Length - 1)
+            {
+                nextEscapeIndex = message.IndexOf(escapeChar, i + 1);
+            }
+
+            if (nextEscapeIndex < 0)
+            {
+                length = message.Length - startIndex;
+                break;
+            }
+
+            length = nextEscapeIndex - startIndex;
+            i = nextEscapeIndex - 1;
+        }
+
+        if (startIndex != -1)
+        {
+            _onParseWrite(message, startIndex, length, background, foreground);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDigit(char c) => (uint)(c - '0') <= ('9' - '0');
+
+    internal const string DefaultForegroundColor = "\u001b[39m\u001b[22m"; // reset to default foreground color
+    internal const string DefaultBackgroundColor = "\u001b[49m"; // reset to the background color
+
+    internal static string GetForegroundColorEscapeCode(ConsoleColor color)
+    {
+        return color switch
+        {
+            ConsoleColor.Black => "\u001b[30m",
+            ConsoleColor.DarkRed => "\u001b[31m",
+            ConsoleColor.DarkGreen => "\u001b[32m",
+            ConsoleColor.DarkYellow => "\u001b[33m",
+            ConsoleColor.DarkBlue => "\u001b[34m",
+            ConsoleColor.DarkMagenta => "\u001b[35m",
+            ConsoleColor.DarkCyan => "\u001b[36m",
+            ConsoleColor.Gray => "\u001b[37m",
+            ConsoleColor.Red => "\u001b[1m\u001b[31m",
+            ConsoleColor.Green => "\u001b[1m\u001b[32m",
+            ConsoleColor.Yellow => "\u001b[1m\u001b[33m",
+            ConsoleColor.Blue => "\u001b[1m\u001b[34m",
+            ConsoleColor.Magenta => "\u001b[1m\u001b[35m",
+            ConsoleColor.Cyan => "\u001b[1m\u001b[36m",
+            ConsoleColor.White => "\u001b[1m\u001b[37m",
+            _ => DefaultForegroundColor // default foreground color
+        };
+    }
+
+    internal static string GetBackgroundColorEscapeCode(ConsoleColor color)
+    {
+        return color switch
+        {
+            ConsoleColor.Black => "\u001b[40m",
+            ConsoleColor.DarkRed => "\u001b[41m",
+            ConsoleColor.DarkGreen => "\u001b[42m",
+            ConsoleColor.DarkYellow => "\u001b[43m",
+            ConsoleColor.DarkBlue => "\u001b[44m",
+            ConsoleColor.DarkMagenta => "\u001b[45m",
+            ConsoleColor.DarkCyan => "\u001b[46m",
+            ConsoleColor.Gray => "\u001b[47m",
+            _ => DefaultBackgroundColor // Use default background color
+        };
+    }
+
+    private static bool TryGetForegroundColor(int number, bool isBright, out ConsoleColor? color)
+    {
+        color = number switch
+        {
+            30 => ConsoleColor.Black,
+            31 => isBright ? ConsoleColor.Red : ConsoleColor.DarkRed,
+            32 => isBright ? ConsoleColor.Green : ConsoleColor.DarkGreen,
+            33 => isBright ? ConsoleColor.Yellow : ConsoleColor.DarkYellow,
+            34 => isBright ? ConsoleColor.Blue : ConsoleColor.DarkBlue,
+            35 => isBright ? ConsoleColor.Magenta : ConsoleColor.DarkMagenta,
+            36 => isBright ? ConsoleColor.Cyan : ConsoleColor.DarkCyan,
+            37 => isBright ? ConsoleColor.White : ConsoleColor.Gray,
+            _ => null
+        };
+        return color != null || number == 39;
+    }
+
+    private static bool TryGetBackgroundColor(int number, out ConsoleColor? color)
+    {
+        color = number switch
+        {
+            40 => ConsoleColor.Black,
+            41 => ConsoleColor.DarkRed,
+            42 => ConsoleColor.DarkGreen,
+            43 => ConsoleColor.DarkYellow,
+            44 => ConsoleColor.DarkBlue,
+            45 => ConsoleColor.DarkMagenta,
+            46 => ConsoleColor.DarkCyan,
+            47 => ConsoleColor.Gray,
+            _ => null
+        };
+        return color != null || number == 49;
+    }
+}

--- a/src/Hamelin/Logging/LogAttributes.cs
+++ b/src/Hamelin/Logging/LogAttributes.cs
@@ -1,0 +1,6 @@
+namespace Hamelin.Logging;
+
+internal class LogAttributes
+{
+    public required string StepName { get; init; }
+}

--- a/src/Hamelin/Logging/LogLevels.cs
+++ b/src/Hamelin/Logging/LogLevels.cs
@@ -1,0 +1,13 @@
+namespace Hamelin.Logging;
+
+internal static class LogMessageLevels
+{
+    // Some levels have a space added to maintain equal character count
+    // This means logs are orderly and easier to read
+    public static string Trace => "[TRACE]";
+    public static string Debug => "[DEBUG]";
+    public static string Information => "[INFO ]";
+    public static string Warning => "[WARN ]";
+    public static string Error => "[ERROR]";
+    public static string Critical => "[CRIT ]";
+}

--- a/src/Hamelin/Logging/PipelineConsoleFormatter.cs
+++ b/src/Hamelin/Logging/PipelineConsoleFormatter.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Hamelin.Logging;
+
+/// <summary>
+/// Formats CI/CD log entries in a concise and readable way.
+/// </summary>
+public class PipelineConsoleFormatter : ConsoleFormatter, IDisposable
+{
+    internal const string FormatterName = "HamelinConsole";
+
+    private readonly IDisposable? _optionsReloadToken;
+    private readonly TimeProvider _time;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PipelineConsoleFormatter" />
+    /// </summary>
+    public PipelineConsoleFormatter(IOptionsMonitor<PipelineConsoleFormatterOptions> options, TimeProvider timeProvider) : base(FormatterName)
+    {
+        ReloadLoggerOptions(options.CurrentValue);
+        _optionsReloadToken = options.OnChange(ReloadLoggerOptions);
+        _time = timeProvider;
+    }
+
+    [MemberNotNull(nameof(FormatterOptions))]
+    private void ReloadLoggerOptions(PipelineConsoleFormatterOptions options)
+    {
+        FormatterOptions = options;
+    }
+
+    /// <inheritdoc cref="IDisposable" />
+    public void Dispose()
+    {
+        _optionsReloadToken?.Dispose();
+    }
+
+    internal PipelineConsoleFormatterOptions FormatterOptions { get; set; }
+
+    /// <summary>
+    /// Writes the log message to the specified TextWriter
+    /// </summary>
+    /// <param name="logEntry"></param>
+    /// <param name="scopeProvider"></param>
+    /// <param name="textWriter"></param>
+    /// <typeparam name="TState"></typeparam>
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        string? message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+
+        if (logEntry.Exception is null && string.IsNullOrEmpty(message))
+        {
+            return;
+        }
+
+        DateTimeOffset logTime = GetCurrentDateTime();
+
+        string? category = GetStepName(scopeProvider);
+
+        WriteMessage(textWriter, message, logTime, logEntry.LogLevel, category);
+
+        if (logEntry.Exception is not null)
+        {
+            WriteMessage(textWriter, logEntry.Exception.ToString(), logTime, logEntry.LogLevel, category);
+        }
+    }
+
+    private string? GetStepName(IExternalScopeProvider? scopeProvider)
+    {
+        if (scopeProvider is null || !FormatterOptions.IncludeScopes || !FormatterOptions.IncludeStepNames)
+        {
+            return null;
+        }
+
+        string? stepName = null;
+
+        scopeProvider.ForEachScope((scope, state) =>
+        {
+            if (scope is not LogAttributes logAttributes)
+            {
+                return;
+            }
+
+            stepName = logAttributes.StepName;
+        }, stepName);
+
+        return stepName;
+    }
+
+    private void WriteMessage(TextWriter textWriter, string message, DateTimeOffset logTime, LogLevel logLevel, string? stepName)
+    {
+        string[] messageLines = message.Split(Environment.NewLine);
+        foreach (string messageLine in messageLines)
+        {
+            WriteMessageLine(textWriter, messageLine, logTime, logLevel, stepName);
+        }
+    }
+
+    private void WriteMessageLine(TextWriter textWriter, string message, DateTimeOffset logTime, LogLevel logLevel, string? stepName)
+    {
+        ConsoleColors logLevelColors = GetLogLevelConsoleColors(logLevel);
+        string logLevelString = GetLogLevelString(logLevel);
+
+        string? timestamp = null;
+        string? timestampFormat = FormatterOptions.TimestampFormat;
+        if (timestampFormat != null)
+        {
+            timestamp = logTime.ToString(timestampFormat);
+            textWriter.Write(' ');
+        }
+
+        if (!string.IsNullOrEmpty(timestamp))
+        {
+            textWriter.Write(timestamp);
+            textWriter.Write(' ');
+        }
+
+        if (!string.IsNullOrEmpty(logLevelString))
+        {
+            textWriter.WriteColoredMessage(logLevelString, logLevelColors.Background, logLevelColors.Foreground);
+            textWriter.Write(' ');
+        }
+
+        if (stepName is not null)
+        {
+            textWriter.Write(stepName);
+            textWriter.Write(": ");
+        }
+
+        textWriter.WriteLine(message);
+    }
+
+    private DateTimeOffset GetCurrentDateTime()
+    {
+        if (FormatterOptions.TimestampFormat is null)
+        {
+            return DateTimeOffset.MinValue;
+        }
+
+        return FormatterOptions.UseUtcTimestamp ? _time.GetUtcNow() : _time.GetLocalNow();
+    }
+
+    private static string GetLogLevelString(LogLevel logLevel) =>
+        logLevel switch
+        {
+            LogLevel.None => string.Empty,
+            LogLevel.Trace => LogMessageLevels.Trace,
+            LogLevel.Debug => LogMessageLevels.Debug,
+            LogLevel.Information => LogMessageLevels.Information,
+            LogLevel.Warning => LogMessageLevels.Warning,
+            LogLevel.Error => LogMessageLevels.Error,
+            LogLevel.Critical => LogMessageLevels.Critical,
+            _ => $"[LEVEL {logLevel}]"
+        };
+
+    private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
+    {
+        if (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled)
+        {
+            return new ConsoleColors(null, null);
+        }
+
+        // We must explicitly set the background color if we are setting the foreground color,
+        // since just setting one can look bad on the users console.
+        return logLevel switch
+        {
+            LogLevel.Trace => new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black),
+            LogLevel.Debug => new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black),
+            LogLevel.Information => new ConsoleColors(ConsoleColor.DarkGreen, ConsoleColor.Black),
+            LogLevel.Warning => new ConsoleColors(ConsoleColor.Yellow, ConsoleColor.Black),
+            LogLevel.Error => new ConsoleColors(ConsoleColor.Red, ConsoleColor.Black),
+            LogLevel.Critical => new ConsoleColors(ConsoleColor.White, ConsoleColor.DarkRed),
+            _ => new ConsoleColors(null, null)
+        };
+    }
+
+    private readonly struct ConsoleColors(ConsoleColor? foreground, ConsoleColor? background)
+    {
+        public ConsoleColor? Foreground { get; } = foreground;
+
+        public ConsoleColor? Background { get; } = background;
+    }
+}

--- a/src/Hamelin/Logging/PipelineConsoleFormatterOptions.cs
+++ b/src/Hamelin/Logging/PipelineConsoleFormatterOptions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging.Console;
+
+namespace Hamelin.Logging;
+
+/// <summary>
+/// Options for the Hamelin console log formatter.
+/// </summary>
+public class PipelineConsoleFormatterOptions : ConsoleFormatterOptions
+{
+    /// <summary>
+    /// Creates a new <see cref="PipelineConsoleFormatterOptions" /> with the default behaviours.
+    /// </summary>
+    public PipelineConsoleFormatterOptions()
+    {
+        TimestampFormat = "o"; // ISO 8601
+        ColorBehavior = LoggerColorBehavior.Default;
+        IncludeScopes = true;
+        IncludeStepNames = true;
+    }
+
+    /// <summary>
+    /// Determines when to use color when logging messages.
+    /// </summary>
+    public LoggerColorBehavior ColorBehavior { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether step names are included.
+    /// </summary>
+    /// <value>
+    /// <see langword="true" /> if step names are included.
+    /// </value>
+    public bool IncludeStepNames { get; set; }
+}

--- a/src/Hamelin/Logging/TextWriterExtensions.cs
+++ b/src/Hamelin/Logging/TextWriterExtensions.cs
@@ -1,0 +1,30 @@
+namespace Hamelin.Logging;
+
+internal static class TextWriterExtensions
+{
+    public static void WriteColoredMessage(this TextWriter textWriter, string message, ConsoleColor? background, ConsoleColor? foreground)
+    {
+        // Order: backgroundcolor, foregroundcolor, Message, reset foregroundcolor, reset backgroundcolor
+        if (background.HasValue)
+        {
+            textWriter.Write(AnsiParser.GetBackgroundColorEscapeCode(background.Value));
+        }
+
+        if (foreground.HasValue)
+        {
+            textWriter.Write(AnsiParser.GetForegroundColorEscapeCode(foreground.Value));
+        }
+
+        textWriter.Write(message);
+
+        if (foreground.HasValue)
+        {
+            textWriter.Write(AnsiParser.DefaultForegroundColor); // reset to default foreground color
+        }
+
+        if (background.HasValue)
+        {
+            textWriter.Write(AnsiParser.DefaultBackgroundColor); // reset to the background color
+        }
+    }
+}

--- a/src/Hamelin/PipelineApplicationBuilder.cs
+++ b/src/Hamelin/PipelineApplicationBuilder.cs
@@ -52,6 +52,8 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
 
         _innerBuilder.Services
             .AddOptions<PipelineExecutionOptions>();
+
+        Logging.AddPipelineConsoleFormatter();
     }
 
     /// <inheritdoc />
@@ -93,6 +95,8 @@ public class PipelineApplicationBuilder : IHostApplicationBuilder
 
     private static void ApplyServices(IServiceCollection services)
     {
+        services.AddSingleton(TimeProvider.System);
+
         services.TryAddSingleton<IPipelineRunner, DefaultPipelineRunner>();
         services.TryAddSingleton<IPipelineStepRunner, DefaultPipelineStepRunner>();
         services.TryAddScoped<IFileSystem>(_ => new PhysicalFileSystem(System.Environment.CurrentDirectory));

--- a/src/Hamelin/StepExecutionSummary.cs
+++ b/src/Hamelin/StepExecutionSummary.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Hamelin;
 
 /// <summary>
@@ -5,6 +7,23 @@ namespace Hamelin;
 /// </summary>
 public class StepExecutionSummary
 {
+    /// <summary>
+    /// Creates a new <see cref="StepExecutionSummary"/>
+    /// </summary>
+    public StepExecutionSummary() { }
+
+    /// <summary>
+    /// Creates a new <see cref="StepExecutionSummary"/>
+    /// </summary>
+    /// <param name="stepName">The name of the step that this summary is for.</param>
+    /// <param name="result">The result of executing the step.</param>
+    [SetsRequiredMembers]
+    public StepExecutionSummary(string stepName, PipelineStepResult result)
+    {
+        StepName = stepName;
+        Result = result;
+    }
+
     /// <summary>
     /// The name of the step that this summary is for.
     /// </summary>
@@ -14,20 +33,4 @@ public class StepExecutionSummary
     /// The result of executing the step.
     /// </summary>
     public required PipelineStepResult Result { get; init; }
-
-    /// <summary>
-    /// Creates an execution summary for the given step.
-    /// </summary>
-    /// <param name="step">The step to create the summary for.</param>
-    /// <param name="result">The result of the execution.</param>
-    /// <returns>The created summary.</returns>
-    public static StepExecutionSummary FromStep(IPipelineStep step, PipelineStepResult result)
-    {
-        string stepName = step.GetType().Name;
-        return new StepExecutionSummary
-        {
-            StepName = stepName,
-            Result = result
-        };
-    }
 }

--- a/tests/Hamelin.Tests.Unit/Hamelin.Tests.Unit.csproj
+++ b/tests/Hamelin.Tests.Unit/Hamelin.Tests.Unit.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.8.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">

--- a/tests/Hamelin.Tests.Unit/Logging/PipelineConsoleFormatterTests.cs
+++ b/tests/Hamelin.Tests.Unit/Logging/PipelineConsoleFormatterTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Hamelin.Internal;
@@ -202,7 +203,7 @@ public class PipelineConsoleFormatterTests
     }
 
     [Fact]
-    public async Task Log_ForPipelineStep_ShouldIncludeStepName()
+    public async Task Log_ForPipelineStep_ShouldIncludeStepClassName()
     {
         // Arrange
         var formattingOptions = new PipelineConsoleFormatterOptions { ColorBehavior = LoggerColorBehavior.Disabled, IncludeScopes = true, IncludeStepNames = true };
@@ -222,7 +223,31 @@ public class PipelineConsoleFormatterTests
 
         // Assert
         string output = _writer.ToString();
-        output.ShouldContain($"TestStep: {TestStep.TestMessage}");
+        output.ShouldContain($"{nameof(TestStep)}: {TestStep.TestMessage}");
+    }
+
+    [Fact]
+    public async Task Log_ForPipelineStepWithDisplayNameAttribute_ShouldIncludeStepDisplayName()
+    {
+        // Arrange
+        var formattingOptions = new PipelineConsoleFormatterOptions { ColorBehavior = LoggerColorBehavior.Disabled, IncludeScopes = true, IncludeStepNames = true };
+        ReplaceLoggerAndProvider(formattingOptions);
+
+        var testStep = new TestStepWithName(CreateLogger<TestStep>());
+
+        var pipelineRunner = DefaultPipelineRunnerHelpers.CreateRunner(
+            steps: [testStep],
+            logger: CreateLogger<DefaultPipelineRunner>(),
+            stepRunner: DefaultPipelineStepRunnerHelpers.CreateRunner(logger: CreateLogger<DefaultPipelineStepRunner>())
+        );
+
+        // Act
+        _ = await pipelineRunner.RunPipeline(TestContext.Current.CancellationToken);
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain($"{TestStepWithName.CustomName}: {TestStep.TestMessage}");
     }
 }
 
@@ -235,4 +260,10 @@ internal class TestStep(ILogger<TestStep> logger) : IPipelineStep
         logger.LogInformation(TestMessage);
         return Task.CompletedTask;
     }
+}
+
+[DisplayName(CustomName)]
+internal class TestStepWithName(ILogger<TestStep> logger) : TestStep(logger)
+{
+    public const string CustomName = "CustomName";
 }

--- a/tests/Hamelin.Tests.Unit/Logging/PipelineConsoleFormatterTests.cs
+++ b/tests/Hamelin.Tests.Unit/Logging/PipelineConsoleFormatterTests.cs
@@ -1,0 +1,238 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Hamelin.Internal;
+using Hamelin.Logging;
+using Hamelin.Tests.Unit.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Hamelin.Tests.Unit.Logging;
+
+[Collection("Console")]
+public class PipelineConsoleFormatterTests
+{
+    private readonly StringWriter _writer = new();
+    private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.UtcNow);
+    private ILogger<PipelineConsoleFormatterTests> _logger;
+    private ConsoleLoggerProvider _provider;
+
+    public PipelineConsoleFormatterTests()
+    {
+        Console.SetOut(_writer);
+        ReplaceLoggerAndProvider(new PipelineConsoleFormatterOptions());
+    }
+
+    [MemberNotNull(nameof(_logger))]
+    [MemberNotNull(nameof(_provider))]
+    private void ReplaceLoggerAndProvider(PipelineConsoleFormatterOptions options)
+    {
+        _provider = CreateLoggerProvider(options);
+        _logger = CreateLogger<PipelineConsoleFormatterTests>();
+    }
+
+    private ConsoleLoggerProvider CreateLoggerProvider(PipelineConsoleFormatterOptions formatterOptions)
+    {
+        var formatterOptionsMonitor = Substitute.For<IOptionsMonitor<PipelineConsoleFormatterOptions>>();
+        formatterOptionsMonitor.CurrentValue.Returns(formatterOptions);
+
+        var formatter = new PipelineConsoleFormatter(formatterOptionsMonitor, _timeProvider);
+
+        var loggerOptionsMonitor = Substitute.For<IOptionsMonitor<ConsoleLoggerOptions>>();
+        var loggerOptions = new ConsoleLoggerOptions { FormatterName = PipelineConsoleFormatter.FormatterName };
+        loggerOptionsMonitor.CurrentValue.Returns(loggerOptions);
+
+        return new ConsoleLoggerProvider(loggerOptionsMonitor, [formatter]);
+    }
+
+    private ILogger<T> CreateLogger<T>() =>
+        LoggerFactory
+            .Create(l =>
+            {
+                l.SetMinimumLevel(LogLevel.Trace);
+                l.Services.AddSingleton<TimeProvider>(_timeProvider);
+                l.ClearProviders();
+                l.AddProvider(_provider);
+            })
+            .CreateLogger<T>();
+
+    [Fact]
+    public void LogCritical_TextOnly_LogsError()
+    {
+        // Arrange
+
+        // Act
+        _logger.LogCritical("Test Critical");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Critical);
+        output.ShouldContain("Test Critical");
+    }
+
+    [Fact]
+    public void LogError_TextOnly_LogsError()
+    {
+        // Arrange
+
+        // Act
+        _logger.LogError("Test Error");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Error);
+        output.ShouldContain("Test Error");
+    }
+
+    [Fact]
+    public void LogError_WithException_LogsErrorWithExceptionDetails()
+    {
+        // Arrange
+        var ex = new Exception("Test Exception");
+
+        // Act
+        _logger.LogError(ex, "Test Error");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Error);
+        output.ShouldContain("Test Error");
+        output.ShouldContain("System.Exception: Test Exception");
+    }
+
+    [Fact]
+    public void LogWarning_TextOnly_LogsWarning()
+    {
+        // Arrange
+
+        // Act
+        _logger.LogWarning("Test Warning");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Warning);
+        output.ShouldContain("Test Warning");
+    }
+
+    [Fact]
+    public void LogInformation_TextOnly_LogsInformation()
+    {
+        // Arrange
+
+        // Act
+        _logger.LogInformation("Test Information");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Information);
+        output.ShouldContain("Test Information");
+    }
+
+    [Fact]
+    public void LogDebug_TextOnly_LogsDebug()
+    {
+        // Arrange
+
+        // Act
+        _logger.LogDebug("Test Debug");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Debug);
+        output.ShouldContain("Test Debug");
+    }
+
+    [Fact]
+    public void LogTrace_TextOnly_LogsTrace()
+    {
+        // Arrange
+
+        // Act
+        _logger.LogTrace("Test Trace");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain(LogMessageLevels.Trace);
+        output.ShouldContain("Test Trace");
+    }
+
+    [Theory]
+    [InlineData("o")]
+    [InlineData("dd MMM HH:mm:ss")]
+    [InlineData("r")]
+    public void Log_WithTimeFormatting_MatchesSystemTimeFormatting(string format)
+    {
+        // Arrange
+        ReplaceLoggerAndProvider(new PipelineConsoleFormatterOptions { UseUtcTimestamp = true, TimestampFormat = format });
+
+        // Act
+        _logger.LogInformation("Test");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        string expectedFormattedTime = _timeProvider.GetUtcNow().ToString(format);
+        output.ShouldContain(expectedFormattedTime);
+    }
+
+    [Fact]
+    public void Log_WithNullTimeFormat_ShouldOmitTimestamp()
+    {
+        // Arrange
+        ReplaceLoggerAndProvider(new PipelineConsoleFormatterOptions { TimestampFormat = null, ColorBehavior = LoggerColorBehavior.Disabled });
+
+        // Act
+        _logger.LogInformation("Test");
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        // Testing for the absence of something that can be in any format is tricky
+        // This test is sensitive to other format changes, it would be nice to find a more reliable test
+        output.ShouldStartWith(LogMessageLevels.Information);
+    }
+
+    [Fact]
+    public async Task Log_ForPipelineStep_ShouldIncludeStepName()
+    {
+        // Arrange
+        var formattingOptions = new PipelineConsoleFormatterOptions { ColorBehavior = LoggerColorBehavior.Disabled, IncludeScopes = true, IncludeStepNames = true };
+        ReplaceLoggerAndProvider(formattingOptions);
+
+        var testStep = new TestStep(CreateLogger<TestStep>());
+
+        var pipelineRunner = DefaultPipelineRunnerHelpers.CreateRunner(
+            steps: [testStep],
+            logger: CreateLogger<DefaultPipelineRunner>(),
+            stepRunner: DefaultPipelineStepRunnerHelpers.CreateRunner(logger: CreateLogger<DefaultPipelineStepRunner>())
+        );
+
+        // Act
+        _ = await pipelineRunner.RunPipeline(TestContext.Current.CancellationToken);
+        _provider.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldContain($"TestStep: {TestStep.TestMessage}");
+    }
+}
+
+internal class TestStep(ILogger<TestStep> logger) : IPipelineStep
+{
+    public const string TestMessage = "Step 'Run' method called";
+
+    public Task Run(CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation(TestMessage);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Adds `PipelineConsoleFormatter` and associated options and extensions to enable it on pipelines.

This formatter provides a simple single-line logging experience (exceptions remain multi-line). This formatter is intended to aid local running/debugging of pipelines, as well as to provide a fall-back in case there is no runtime/platform provider formatter available.

The default format is `<time (iso)> <log level> <step name>: <message>`.

An example of the default format: 
<img width="1673" height="1068" alt="image" src="https://github.com/user-attachments/assets/9dcb4e0c-077f-4e9e-9056-acecc1f0a892" />
